### PR TITLE
Fix 0746294

### DIFF
--- a/playbooks/08 - War Room Automation/Set War Room Live and Notify Responders.json
+++ b/playbooks/08 - War Room Automation/Set War Room Live and Notify Responders.json
@@ -181,6 +181,7 @@
             "name": "War room send notifications",
             "description": null,
             "arguments": {
+                "when": "{{vars.input.params.notifyAllResponders}}",
                 "arguments": {
                     "warRoom": "{{vars.input.records[0]}}",
                     "emailBody": "{{vars.steps.Set_email_body.data['formatted_string']}}",


### PR DESCRIPTION
Issue:
The Go Live playbook was ignoring the "Notify All Responders" parameter

Fix:
Add a condition to only send the email if "Notify All Responders" is checked