### PR TITLE
bugfix-0798959

### DIFF
--- a/playbooks/03 - Enrich/Indicator (Type File) - Get Reputation.json
+++ b/playbooks/03 - Enrich/Indicator (Type File) - Get Reputation.json
@@ -335,7 +335,7 @@
                 "name": "VirusTotal",
                 "config": "4a22a2c4-a1b5-4b9d-ba9b-df87a8cebce9",
                 "params": {
-                    "analysis_id": "{{vars.steps.Upload_file_to_VirusTotal.data.data.id}}"
+                    "analysis_id": "{{vars.steps.Upload_file_to_VirusTotal.data.id}}"
                 },
                 "version": "2.0.0",
                 "do_until": {


### PR DESCRIPTION
Get Reputation failed with an error "Invalid params provided :: Parameters Analysis ID have either blank value or not provided  Connector :: virustotalV2.2.0"