### PR TITLE
bugfix

### DIFF
--- a/playbooks/06 - IRP - War Room/Set up War Room from Alerts.json
+++ b/playbooks/06 - IRP - War Room/Set up War Room from Alerts.json
@@ -88,7 +88,7 @@
             "description": null,
             "arguments": {
                 "route": "ef94c00f-2a38-4a78-a34a-c2468b3764f8",
-                "title": "Create War Room",
+                "title": "Set up War Room",
                 "resources": [
                     "alerts"
                 ],
@@ -243,7 +243,7 @@
                         "filters": []
                     }
                 },
-                "executeButtonText": "Execute",
+                "executeButtonText": "Create",
                 "noRecordExecution": false,
                 "singleRecordExecution": true
             },

--- a/playbooks/06 - IRP - War Room/Set up War Room from Alerts.json
+++ b/playbooks/06 - IRP - War Room/Set up War Room from Alerts.json
@@ -88,7 +88,7 @@
             "description": null,
             "arguments": {
                 "route": "ef94c00f-2a38-4a78-a34a-c2468b3764f8",
-                "title": "Set up War Room",
+                "title": "Setup War Room",
                 "resources": [
                     "alerts"
                 ],

--- a/playbooks/06 - IRP - War Room/Set up War Room from Incidents.json
+++ b/playbooks/06 - IRP - War Room/Set up War Room from Incidents.json
@@ -88,7 +88,7 @@
             "description": null,
             "arguments": {
                 "route": "4bfa32ee-7500-4950-baa1-ac23a388b022",
-                "title": "Create War Room",
+                "title": "Set up War Room",
                 "resources": [
                     "incidents"
                 ],
@@ -243,7 +243,7 @@
                         "filters": []
                     }
                 },
-                "executeButtonText": "Execute",
+                "executeButtonText": "Create",
                 "noRecordExecution": false,
                 "singleRecordExecution": true
             },

--- a/playbooks/06 - IRP - War Room/Set up War Room from Incidents.json
+++ b/playbooks/06 - IRP - War Room/Set up War Room from Incidents.json
@@ -88,7 +88,7 @@
             "description": null,
             "arguments": {
                 "route": "4bfa32ee-7500-4950-baa1-ac23a388b022",
-                "title": "Set up War Room",
+                "title": "Setup War Room",
                 "resources": [
                     "incidents"
                 ],


### PR DESCRIPTION
0799430 | Setup War room pop window button 'Execute' should be renamed as 'Create'