### PR TITLE
bugfix

### DIFF
--- a/modules/indicators/mmd.json
+++ b/modules/indicators/mmd.json
@@ -1,6 +1,6 @@
 {
     "@context": "\/api\/3\/contexts\/StagingModelMetadata",
-    "@id": "\/api\/3\/staging_model_metadatas\/a7bde484-86c2-4c6c-a755-f48a77a29fa9",
+    "@id": "\/api\/3\/staging_model_metadatas\/f62fca25-bb3f-4a42-94a2-9018061a6e9d",
     "@type": "StagingModelMetadata",
     "type": "indicators",
     "parentType": null,
@@ -26,6 +26,48 @@
     "indexable": true,
     "writable": true,
     "attributes": [
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/b4984206-6195-4c41-82d5-f0c691b9d235",
+            "@type": "AttributeMetadata",
+            "type": "warrooms",
+            "name": "warrooms",
+            "length": 0,
+            "orderIndex": 33,
+            "formType": "manyToMany",
+            "dataSource": {
+                "model": "warrooms"
+            },
+            "searchable": false,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": true,
+            "inversedField": "indicators",
+            "ownsRelationship": true,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761
+            },
+            "bulkAction": [],
+            "dataSourceFilters": [],
+            "defaultValue": null,
+            "tooltip": "",
+            "visibility": true,
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "b4984206-6195-4c41-82d5-f0c691b9d235",
+            "displayName": "{{ warrooms }}",
+            "descriptions": {
+                "singular": "War Rooms"
+            }
+        },
         {
             "@id": "\/api\/3\/attribute_metadatas\/0204deec-eac2-40cc-992c-58dcde1a6f66",
             "@type": "AttributeMetadata",
@@ -1453,48 +1495,6 @@
             }
         },
         {
-            "@id": "\/api\/3\/attribute_metadatas\/b4984206-6195-4c41-82d5-f0c691b9d235",
-            "@type": "AttributeMetadata",
-            "type": "warrooms",
-            "name": "warrooms",
-            "length": 0,
-            "orderIndex": 33,
-            "formType": "manyToMany",
-            "dataSource": {
-                "model": "warrooms"
-            },
-            "searchable": false,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": true,
-            "inversedField": "indicators",
-            "ownsRelationship": true,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 10485761
-            },
-            "bulkAction": [],
-            "dataSourceFilters": [],
-            "defaultValue": null,
-            "tooltip": "",
-            "visibility": true,
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "b4984206-6195-4c41-82d5-f0c691b9d235",
-            "displayName": "{{ warrooms }}",
-            "descriptions": {
-                "singular": "War Rooms"
-            }
-        },
-        {
             "@id": "\/api\/3\/attribute_metadatas\/058cb69e-c9a6-44ed-afa1-d554bc543a1e",
             "@type": "AttributeMetadata",
             "type": "string",
@@ -1719,7 +1719,7 @@
                 "buttonText": "Update Reputation"
             },
             "dataSourceFilters": [],
-            "defaultValue": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+            "defaultValue": null,
             "tooltip": "",
             "visibility": true,
             "htmlEscape": false,
@@ -1747,7 +1747,7 @@
         "delete_primary_data_after": 60
     },
     "archivalFilters": [],
-    "uuid": "a7bde484-86c2-4c6c-a755-f48a77a29fa9",
+    "uuid": "f62fca25-bb3f-4a42-94a2-9018061a6e9d",
     "displayName": "{{ value }}",
     "descriptions": {
         "plural": "Indicators",

--- a/playbooks/03 - Enrich/Extract Indicators.json
+++ b/playbooks/03 - Enrich/Extract Indicators.json
@@ -37,19 +37,20 @@
                         {
                             "type": "object",
                             "field": "reputation",
-                            "value": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                            "value": "true",
                             "_value": {
-                                "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
-                                "itemValue": "TBD"
+                                "@id": "true",
+                                "display": "TBD",
+                                "itemValue": ""
                             },
-                            "operator": "eq"
+                            "operator": "isnull"
                         }
                     ]
                 },
                 "module": "indicators?$limit=30",
                 "do_until": {
-                    "delay": "65",
-                    "retries": "2",
+                    "delay": 65,
+                    "retries": 2,
                     "condition": "{{vars.result | length == 0}}"
                 },
                 "checkboxFields": false,


### PR DESCRIPTION
0799420 | Extract Indicator Playbook is not setting links to the subsequent sighting of indicator