### PR TITLE
bugfix 0806876 and 0795214

### DIFF
--- a/modules/alerts/mmd.json
+++ b/modules/alerts/mmd.json
@@ -1104,27 +1104,39 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
+                            "field": "reporterEmailBody",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
                         },
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
-                            "_value": {
-                                "itemValue": "Phishing",
-                                "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
-                            },
-                            "type": "object"
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -2202,17 +2214,39 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
+                            "field": "fileEmail",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -2565,18 +2599,8 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
-                        },
                         {
                             "field": "emailClassification",
                             "operator": "isnull",
@@ -2587,6 +2611,31 @@
                                 "@id": "false"
                             },
                             "type": "object"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -2857,7 +2906,7 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
                             "field": "emailFrom",
@@ -2867,14 +2916,29 @@
                             "type": "primitive"
                         },
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -2886,7 +2950,7 @@
             "identifier": false,
             "unique": false,
             "recommend": false,
-            "uuid": "0f5c023a-dcb8-483f-bfe0-aee854d1c1b9",
+            "uuid": "3255a099-7eed-43e9-88a7-e23379a74565",
             "displayName": "{{ emailFrom }}",
             "descriptions": {
                 "singular": "Email From"
@@ -4178,7 +4242,7 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
                             "field": "emailBody",
@@ -4188,7 +4252,7 @@
                             "type": "primitive"
                         },
                         {
-                            "logic": "AND",
+                            "logic": "OR",
                             "filters": [
                                 {
                                     "field": "type",
@@ -4201,11 +4265,14 @@
                                     "type": "object"
                                 },
                                 {
-                                    "field": "emailBody",
-                                    "operator": "isnull",
-                                    "_operator": "isnull",
-                                    "value": "false",
-                                    "type": "primitive"
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
                                 }
                             ]
                         }
@@ -4321,7 +4388,7 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
                             "field": "emailHeaders",
@@ -4331,7 +4398,7 @@
                             "type": "primitive"
                         },
                         {
-                            "logic": "AND",
+                            "logic": "OR",
                             "filters": [
                                 {
                                     "field": "type",
@@ -4344,11 +4411,14 @@
                                     "type": "object"
                                 },
                                 {
-                                    "field": "emailHeaders",
-                                    "operator": "isnull",
-                                    "_operator": "isnull",
-                                    "value": "false",
-                                    "type": "primitive"
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
                                 }
                             ]
                         }
@@ -4403,7 +4473,7 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
                             "field": "emailTo",
@@ -4413,14 +4483,29 @@
                             "type": "primitive"
                         },
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -5574,17 +5659,39 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
+                            "field": "recipientEmailAddress",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -5757,27 +5864,39 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
+                            "field": "reporter",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
                         },
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
-                            "_value": {
-                                "itemValue": "Phishing",
-                                "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
-                            },
-                            "type": "object"
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -5830,7 +5949,7 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
                             "field": "returnPath",
@@ -5838,6 +5957,31 @@
                             "_operator": "isnull",
                             "value": "false",
                             "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -5890,17 +6034,39 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
+                            "field": "senderDomain",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -5953,17 +6119,39 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
+                            "field": "senderEmailAddress",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -6609,7 +6797,7 @@
                 {
                     "sort": [],
                     "limit": 30,
-                    "logic": "OR",
+                    "logic": "AND",
                     "filters": [
                         {
                             "field": "emailSubject",
@@ -6619,14 +6807,29 @@
                             "type": "primitive"
                         },
                         {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         }
                     ]
                 }

--- a/playbooks/03 - Enrich/Indicator (Type File - MD5) - Get Reputation.json
+++ b/playbooks/03 - Enrich/Indicator (Type File - MD5) - Get Reputation.json
@@ -99,21 +99,11 @@
                     "filters": [
                         {
                             "type": "object",
-                            "field": "typeofindicator",
-                            "value": "\/api\/3\/picklists\/0ca054f2-d923-4992-a4a7-c516e6df281e",
-                            "_value": {
-                                "@id": "\/api\/3\/picklists\/0ca054f2-d923-4992-a4a7-c516e6df281e",
-                                "itemValue": "FileHash-MD5"
-                            },
-                            "operator": "eq"
-                        },
-                        {
-                            "type": "object",
                             "field": "indicatorStatus",
                             "value": "\/api\/3\/picklists\/4218cb58-4de5-4eff-ad08-185d36ef9bab",
                             "_value": {
                                 "@id": "\/api\/3\/picklists\/4218cb58-4de5-4eff-ad08-185d36ef9bab",
-                                "itemValue": "Whitelisted"
+                                "itemValue": "Excluded"
                             },
                             "operator": "neq"
                         },
@@ -138,6 +128,44 @@
                                     "_value": {
                                         "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
                                         "itemValue": "TBD"
+                                    },
+                                    "operator": "eq"
+                                }
+                            ]
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "type": "object",
+                                    "field": "typeofindicator",
+                                    "value": "\/api\/3\/picklists\/0ca054f2-d923-4992-a4a7-c516e6df281e",
+                                    "_value": {
+                                        "@id": "\/api\/3\/picklists\/0ca054f2-d923-4992-a4a7-c516e6df281e",
+                                        "display": "FileHash-MD5",
+                                        "itemValue": "FileHash-MD5"
+                                    },
+                                    "operator": "eq"
+                                },
+                                {
+                                    "type": "object",
+                                    "field": "typeofindicator",
+                                    "value": "\/api\/3\/picklists\/4ea7b083-a0af-41ea-8d7c-7ace16021722",
+                                    "_value": {
+                                        "@id": "\/api\/3\/picklists\/4ea7b083-a0af-41ea-8d7c-7ace16021722",
+                                        "display": "FileHash-SHA256",
+                                        "itemValue": "FileHash-SHA256"
+                                    },
+                                    "operator": "eq"
+                                },
+                                {
+                                    "type": "object",
+                                    "field": "typeofindicator",
+                                    "value": "\/api\/3\/picklists\/143e40b0-e643-468d-b968-a542fc85f08d",
+                                    "_value": {
+                                        "@id": "\/api\/3\/picklists\/143e40b0-e643-468d-b968-a542fc85f08d",
+                                        "display": "FileHash-SHA1",
+                                        "itemValue": "FileHash-SHA1"
                                     },
                                     "operator": "eq"
                                 }


### PR DESCRIPTION
Mantis #0795214

Unit Test Case:

- Validated playbook execution for IOC Types FileHash-MD5, FileHash-SHA256 and FileHash-SHA1
The playbook execution was successful

Mantis #0806876

Unit Cases
- Added visibility conditions to the following email related fields in alert mmd
- **Condition:** Following fields should be visible for Alert Type "Phishing"  
    * Email Recipients (To)
    * Recipient Email Address
    * Sender Domain
    * Sender Email Address
    * Email
    * Email Body
    * Email From
    * Email Headers
    * Email Subject
    * Reporter Email Body
    * Return Path
    * Reporter

- Validated that all the above-mentioned fields are visible in Alert SVT