### PR TITLE
bugfixes 0806876 and 0795214 

### DIFF
--- a/modules/alerts/mmd.json
+++ b/modules/alerts/mmd.json
@@ -1,6 +1,6 @@
 {
     "@context": "\/api\/3\/contexts\/StagingModelMetadata",
-    "@id": "\/api\/3\/staging_model_metadatas\/fafe57d3-5c23-4d51-9a6c-4f417ea3b8af",
+    "@id": "\/api\/3\/staging_model_metadatas\/c8c8fa5f-4dde-4282-9129-8ec0aa63a045",
     "@type": "StagingModelMetadata",
     "type": "alerts",
     "parentType": null,
@@ -875,80 +875,6 @@
             "displayName": "{{ userName }}",
             "descriptions": {
                 "singular": "Username"
-            }
-        },
-        {
-            "@id": "\/api\/3\/attribute_metadatas\/8dd3869f-8c1f-4121-aed4-7d40b7b37c76",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "reporterEmailBody",
-            "length": 0,
-            "orderIndex": 80,
-            "formType": "richtext",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "_enableRange": false,
-                "required": false,
-                "minlength": 0,
-                "maxlength": 10485761
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
-                            "_value": {
-                                "itemValue": "Phishing",
-                                "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
-                            },
-                            "type": "object"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "8dd3869f-8c1f-4121-aed4-7d40b7b37c76",
-            "displayName": "{{ reporterEmailBody }}",
-            "descriptions": {
-                "singular": "Reporter Email Body"
             }
         },
         {
@@ -1974,72 +1900,6 @@
             }
         },
         {
-            "@id": "\/api\/3\/attribute_metadatas\/dc309f27-217c-4f15-b93f-5006cceb37b8",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "fileEmail",
-            "length": 0,
-            "orderIndex": 46,
-            "formType": "file",
-            "dataSource": {
-                "model": "files"
-            },
-            "searchable": false,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "_enableRange": false,
-                "required": false,
-                "minlength": 0,
-                "maxlength": 10485761
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": null,
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "dc309f27-217c-4f15-b93f-5006cceb37b8",
-            "displayName": "{{ fileEmail }}",
-            "descriptions": {
-                "singular": "Email"
-            }
-        },
-        {
             "@id": "\/api\/3\/attribute_metadatas\/dc4a2228-2831-4e8e-a7bf-60e93a47f808",
             "@type": "AttributeMetadata",
             "type": "string",
@@ -2583,159 +2443,6 @@
             "displayName": "{{ deviceOwner }}",
             "descriptions": {
                 "singular": "Device Owner"
-            }
-        },
-        {
-            "@id": "\/api\/3\/attribute_metadatas\/0f5c023a-dcb8-483f-bfe0-aee854d1c1b9",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "emailFrom",
-            "length": 0,
-            "orderIndex": 48,
-            "formType": "email",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 1024
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "emailFrom",
-                            "operator": "isnull",
-                            "_operator": "isnull",
-                            "value": "false",
-                            "type": "primitive"
-                        },
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "0f5c023a-dcb8-483f-bfe0-aee854d1c1b9",
-            "displayName": "{{ emailFrom }}",
-            "descriptions": {
-                "singular": "Email From"
-            }
-        },
-        {
-            "@id": "\/api\/3\/attribute_metadatas\/494d9f84-6000-41b8-9d9b-977132931fbe",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "emailHeaders",
-            "length": 0,
-            "orderIndex": 49,
-            "formType": "textarea",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "_enableRange": false,
-                "required": false,
-                "minlength": 0,
-                "maxlength": 10485761
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "emailHeaders",
-                            "operator": "isnull",
-                            "_operator": "isnull",
-                            "value": "false",
-                            "type": "primitive"
-                        },
-                        {
-                            "logic": "AND",
-                            "filters": [
-                                {
-                                    "field": "type",
-                                    "operator": "eq",
-                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                                    "_value": {
-                                        "itemValue": "Suspicious Email",
-                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                                    },
-                                    "type": "object"
-                                },
-                                {
-                                    "field": "emailHeaders",
-                                    "operator": "isnull",
-                                    "_operator": "isnull",
-                                    "value": "false",
-                                    "type": "primitive"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "494d9f84-6000-41b8-9d9b-977132931fbe",
-            "displayName": "{{ emailHeaders }}",
-            "descriptions": {
-                "singular": "Email Headers"
             }
         },
         {
@@ -4103,89 +3810,6 @@
             }
         },
         {
-            "@id": "\/api\/3\/attribute_metadatas\/c7df8348-e699-4b15-b195-a1b2dbfc2dab",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "emailBody",
-            "length": null,
-            "orderIndex": 47,
-            "formType": "richtext",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "_enableRange": false,
-                "required": false,
-                "minlength": 0,
-                "maxlength": 10485761
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "emailBody",
-                            "operator": "isnull",
-                            "_operator": "isnull",
-                            "value": "false",
-                            "type": "primitive"
-                        },
-                        {
-                            "logic": "AND",
-                            "filters": [
-                                {
-                                    "field": "type",
-                                    "operator": "eq",
-                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                                    "_value": {
-                                        "itemValue": "Suspicious Email",
-                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                                    },
-                                    "type": "object"
-                                },
-                                {
-                                    "field": "emailBody",
-                                    "operator": "isnull",
-                                    "_operator": "isnull",
-                                    "value": "false",
-                                    "type": "primitive"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "c7df8348-e699-4b15-b195-a1b2dbfc2dab",
-            "displayName": "{{ emailBody }}",
-            "descriptions": {
-                "singular": "Email Body"
-            }
-        },
-        {
             "@id": "\/api\/3\/attribute_metadatas\/077884d2-ee6d-4f9f-9646-e0c1a2b15b55",
             "@type": "AttributeMetadata",
             "type": "string",
@@ -4243,76 +3867,6 @@
             "displayName": "{{ filePath }}",
             "descriptions": {
                 "singular": "File Path"
-            }
-        },
-        {
-            "@id": "\/api\/3\/attribute_metadatas\/3255a099-7eed-43e9-88a7-e23379a74565",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "emailTo",
-            "length": 0,
-            "orderIndex": 50,
-            "formType": "text",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 1024
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "emailTo",
-                            "operator": "isnull",
-                            "_operator": "isnull",
-                            "value": "false",
-                            "type": "primitive"
-                        },
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "3255a099-7eed-43e9-88a7-e23379a74565",
-            "displayName": "{{ emailTo }}",
-            "descriptions": {
-                "singular": "Email Recipients (To)"
             }
         },
         {
@@ -5302,70 +4856,6 @@
             }
         },
         {
-            "@id": "\/api\/3\/attribute_metadatas\/aa8d9294-3ed2-4538-8f7a-21f508b189db",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "recipientEmailAddress",
-            "length": null,
-            "orderIndex": 76,
-            "formType": "textarea",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 10485761,
-                "_enableRange": false
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "aa8d9294-3ed2-4538-8f7a-21f508b189db",
-            "displayName": "{{ recipientEmailAddress }}",
-            "descriptions": {
-                "singular": "Recipient Email Address"
-            }
-        },
-        {
             "@id": "\/api\/3\/attribute_metadatas\/5aa57f59-e98d-4ae7-b6c7-f1ff0d7ea98c",
             "@type": "AttributeMetadata",
             "type": "string",
@@ -5483,265 +4973,6 @@
             "displayName": "{{ registryKeyValue }}",
             "descriptions": {
                 "singular": "Registry Key Value"
-            }
-        },
-        {
-            "@id": "\/api\/3\/attribute_metadatas\/59e3d9eb-fa06-4e07-bd26-5169d9f51952",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "reporter",
-            "length": 0,
-            "orderIndex": 79,
-            "formType": "text",
-            "dataSource": [],
-            "searchable": false,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 1024
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
-                            "_value": {
-                                "itemValue": "Phishing",
-                                "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
-                            },
-                            "type": "object"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "59e3d9eb-fa06-4e07-bd26-5169d9f51952",
-            "displayName": "{{ reporter }}",
-            "descriptions": {
-                "singular": "Reporter"
-            }
-        },
-        {
-            "@id": "\/api\/3\/attribute_metadatas\/b8caa0dd-aba9-44d6-ae46-81366c006580",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "returnPath",
-            "length": 0,
-            "orderIndex": 81,
-            "formType": "text",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 1024
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "returnPath",
-                            "operator": "isnull",
-                            "_operator": "isnull",
-                            "value": "false",
-                            "type": "primitive"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "b8caa0dd-aba9-44d6-ae46-81366c006580",
-            "displayName": "{{ returnPath }}",
-            "descriptions": {
-                "singular": "Return Path"
-            }
-        },
-        {
-            "@id": "\/api\/3\/attribute_metadatas\/d9b0de37-6137-4b07-a626-0433ccc30b6f",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "senderDomain",
-            "length": null,
-            "orderIndex": 83,
-            "formType": "text",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 1024
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "d9b0de37-6137-4b07-a626-0433ccc30b6f",
-            "displayName": "{{ senderDomain }}",
-            "descriptions": {
-                "singular": "Sender Domain"
-            }
-        },
-        {
-            "@id": "\/api\/3\/attribute_metadatas\/690d9856-c5e1-4a74-839c-4006d7c58e5a",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "senderEmailAddress",
-            "length": null,
-            "orderIndex": 84,
-            "formType": "text",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 1024
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "690d9856-c5e1-4a74-839c-4006d7c58e5a",
-            "displayName": "{{ senderEmailAddress }}",
-            "descriptions": {
-                "singular": "Sender Email Address"
             }
         },
         {
@@ -6117,17 +5348,17 @@
             }
         },
         {
-            "@id": "\/api\/3\/attribute_metadatas\/302a7b25-aafa-4b18-b3b8-6aaf2ea4ace9",
+            "@id": "\/api\/3\/attribute_metadatas\/b8caa0dd-aba9-44d6-ae46-81366c006580",
             "@type": "AttributeMetadata",
             "type": "string",
-            "name": "uuid",
-            "length": 36,
-            "orderIndex": 91,
-            "formType": null,
+            "name": "returnPath",
+            "length": 0,
+            "orderIndex": 81,
+            "formType": "text",
             "dataSource": [],
-            "searchable": false,
+            "searchable": true,
             "peerReplicable": true,
-            "system": true,
+            "system": false,
             "encrypted": false,
             "gridColumn": false,
             "collection": false,
@@ -6136,27 +5367,71 @@
             "validation": {
                 "required": false,
                 "minlength": 0,
-                "maxlength": 10485761,
-                "_enableRange": false
+                "maxlength": 1024
             },
             "bulkAction": {
-                "allow": false
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
             },
             "dataSourceFilters": [],
             "defaultValue": "",
             "tooltip": "",
-            "visibility": true,
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "returnPath",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "display": "Suspicious Email",
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "display": "Phishing",
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
             "htmlEscape": false,
-            "orphanRemoval": null,
+            "orphanRemoval": false,
             "readable": true,
             "writeable": true,
-            "identifier": true,
+            "identifier": false,
             "unique": false,
             "recommend": false,
-            "uuid": "302a7b25-aafa-4b18-b3b8-6aaf2ea4ace9",
-            "displayName": "{{ uuid }}",
+            "uuid": "b8caa0dd-aba9-44d6-ae46-81366c006580",
+            "displayName": "{{ returnPath }}",
             "descriptions": {
-                "singular": "UUID"
+                "singular": "Return Path"
             }
         },
         {
@@ -6338,76 +5613,6 @@
             }
         },
         {
-            "@id": "\/api\/3\/attribute_metadatas\/435f92e3-92a0-42c8-957f-5efadc433440",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "emailSubject",
-            "length": 0,
-            "orderIndex": 51,
-            "formType": "text",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 2048
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "emailSubject",
-                            "operator": "isnull",
-                            "_operator": "isnull",
-                            "value": "false",
-                            "type": "primitive"
-                        },
-                        {
-                            "field": "type",
-                            "operator": "eq",
-                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                            "_value": {
-                                "itemValue": "Suspicious Email",
-                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                            },
-                            "type": "object"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "435f92e3-92a0-42c8-957f-5efadc433440",
-            "displayName": "{{ emailSubject }}",
-            "descriptions": {
-                "singular": "Email Subject"
-            }
-        },
-        {
             "@id": "\/api\/3\/attribute_metadatas\/145329d0-81c9-43f0-8392-aaba11918a2f",
             "@type": "AttributeMetadata",
             "type": "picklists",
@@ -6532,6 +5737,991 @@
             "descriptions": {
                 "singular": "Closure Reason"
             }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/302a7b25-aafa-4b18-b3b8-6aaf2ea4ace9",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "uuid",
+            "length": 36,
+            "orderIndex": 91,
+            "formType": null,
+            "dataSource": [],
+            "searchable": false,
+            "peerReplicable": true,
+            "system": true,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761,
+                "_enableRange": false
+            },
+            "bulkAction": {
+                "allow": false
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": true,
+            "htmlEscape": false,
+            "orphanRemoval": null,
+            "readable": true,
+            "writeable": true,
+            "identifier": true,
+            "unique": false,
+            "recommend": false,
+            "uuid": "302a7b25-aafa-4b18-b3b8-6aaf2ea4ace9",
+            "displayName": "{{ uuid }}",
+            "descriptions": {
+                "singular": "UUID"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/dc309f27-217c-4f15-b93f-5006cceb37b8",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "fileEmail",
+            "length": 0,
+            "orderIndex": 46,
+            "formType": "file",
+            "dataSource": {
+                "model": "files"
+            },
+            "searchable": false,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "_enableRange": false,
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": null,
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "fileEmail",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "dc309f27-217c-4f15-b93f-5006cceb37b8",
+            "displayName": "{{ fileEmail }}",
+            "descriptions": {
+                "singular": "Email"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/0f5c023a-dcb8-483f-bfe0-aee854d1c1b9",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "emailFrom",
+            "length": 0,
+            "orderIndex": 48,
+            "formType": "email",
+            "dataSource": [],
+            "searchable": true,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 1024
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "emailFrom",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "0f5c023a-dcb8-483f-bfe0-aee854d1c1b9",
+            "displayName": "{{ emailFrom }}",
+            "descriptions": {
+                "singular": "Email From"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/8dd3869f-8c1f-4121-aed4-7d40b7b37c76",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "reporterEmailBody",
+            "length": 0,
+            "orderIndex": 80,
+            "formType": "richtext",
+            "dataSource": [],
+            "searchable": true,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "_enableRange": false,
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "reporterEmailBody",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "8dd3869f-8c1f-4121-aed4-7d40b7b37c76",
+            "displayName": "{{ reporterEmailBody }}",
+            "descriptions": {
+                "singular": "Reporter Email Body"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/59e3d9eb-fa06-4e07-bd26-5169d9f51952",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "reporter",
+            "length": 0,
+            "orderIndex": 79,
+            "formType": "text",
+            "dataSource": [],
+            "searchable": false,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 1024
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "reporter",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "59e3d9eb-fa06-4e07-bd26-5169d9f51952",
+            "displayName": "{{ reporter }}",
+            "descriptions": {
+                "singular": "Reporter"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/d9b0de37-6137-4b07-a626-0433ccc30b6f",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "senderDomain",
+            "length": null,
+            "orderIndex": 83,
+            "formType": "text",
+            "dataSource": [],
+            "searchable": true,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 1024
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "senderDomain",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "d9b0de37-6137-4b07-a626-0433ccc30b6f",
+            "displayName": "{{ senderDomain }}",
+            "descriptions": {
+                "singular": "Sender Domain"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/c7df8348-e699-4b15-b195-a1b2dbfc2dab",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "emailBody",
+            "length": null,
+            "orderIndex": 47,
+            "formType": "richtext",
+            "dataSource": [],
+            "searchable": true,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "_enableRange": false,
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "emailBody",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "c7df8348-e699-4b15-b195-a1b2dbfc2dab",
+            "displayName": "{{ emailBody }}",
+            "descriptions": {
+                "singular": "Email Body"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/3255a099-7eed-43e9-88a7-e23379a74565",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "emailTo",
+            "length": 0,
+            "orderIndex": 50,
+            "formType": "text",
+            "dataSource": [],
+            "searchable": true,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 1024
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "emailTo",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "3255a099-7eed-43e9-88a7-e23379a74565",
+            "displayName": "{{ emailTo }}",
+            "descriptions": {
+                "singular": "Email Recipients (To)"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/aa8d9294-3ed2-4538-8f7a-21f508b189db",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "recipientEmailAddress",
+            "length": null,
+            "orderIndex": 76,
+            "formType": "textarea",
+            "dataSource": [],
+            "searchable": true,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761,
+                "_enableRange": false
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "recipientEmailAddress",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "aa8d9294-3ed2-4538-8f7a-21f508b189db",
+            "displayName": "{{ recipientEmailAddress }}",
+            "descriptions": {
+                "singular": "Recipient Email Address"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/494d9f84-6000-41b8-9d9b-977132931fbe",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "emailHeaders",
+            "length": 0,
+            "orderIndex": 49,
+            "formType": "textarea",
+            "dataSource": [],
+            "searchable": true,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "_enableRange": false,
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "emailHeaders",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "494d9f84-6000-41b8-9d9b-977132931fbe",
+            "displayName": "{{ emailHeaders }}",
+            "descriptions": {
+                "singular": "Email Headers"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/690d9856-c5e1-4a74-839c-4006d7c58e5a",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "senderEmailAddress",
+            "length": null,
+            "orderIndex": 84,
+            "formType": "text",
+            "dataSource": [],
+            "searchable": true,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 1024
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "senderEmailAddress",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "690d9856-c5e1-4a74-839c-4006d7c58e5a",
+            "displayName": "{{ senderEmailAddress }}",
+            "descriptions": {
+                "singular": "Sender Email Address"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/435f92e3-92a0-42c8-957f-5efadc433440",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "emailSubject",
+            "length": 0,
+            "orderIndex": 51,
+            "formType": "text",
+            "dataSource": [],
+            "searchable": true,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 2048
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "emailSubject",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                                    "_value": {
+                                        "itemValue": "Suspicious Email",
+                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "field": "type",
+                                    "operator": "eq",
+                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                                    "_value": {
+                                        "itemValue": "Phishing",
+                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "435f92e3-92a0-42c8-957f-5efadc433440",
+            "displayName": "{{ emailSubject }}",
+            "descriptions": {
+                "singular": "Email Subject"
+            }
         }
     ],
     "system": false,
@@ -6545,7 +6735,7 @@
         "delete_primary_data_after": 60
     },
     "archivalFilters": [],
-    "uuid": "fafe57d3-5c23-4d51-9a6c-4f417ea3b8af",
+    "uuid": "c8c8fa5f-4dde-4282-9129-8ec0aa63a045",
     "displayName": "{{ name }}",
     "descriptions": {
         "plural": "Alerts",

--- a/playbooks/03 - Enrich/Indicator (Type File - MD5) - Get Reputation.json
+++ b/playbooks/03 - Enrich/Indicator (Type File - MD5) - Get Reputation.json
@@ -19,46 +19,76 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Get Reputation from AlienVault OTX",
+            "name": "Compute Additional Summary",
             "description": null,
             "arguments": {
-                "name": "AlienVault-OTX",
-                "config": "3d96900a-f870-4ac6-94d0-00865dbaf86f",
                 "params": {
-                    "page": 1,
-                    "limit": 5,
-                    "user_text": "{{vars.indicator_value}}"
+                    "value": "<div class=\"font-size-11 ng-binding padding-bottom-sm\"><h4 style=\"background: #404142;padding: 5px;text-align: left;color: orange;background: black;\"> Additional Information<\/h4><\/div>\n\n<p>{% if (vars.tags | length > 0) %}<\/p>\n<div class=\"font-size-17 margin-top-12 padding-bottom-sm padding-left-sm padding-bottom-lg\"><strong>Virustotal Tags<\/strong><\/div>\n<table style=\"width: 506px; border-color: #ffffff;\" border=\"1\">\n<tbody>\n<tr>\n<td style=\"width: 45px;font-size:16px;font-weight: normal\"><strong>Tags<\/strong><\/td>\n<td> <div class=\"font-size-14 font-weight-normal\">{{(vars.tags| string).replace(\"(\",\"\").replace(\")\",\"\")}}<\/div><\/td>\n<\/tr>\n<\/tbody>\n<\/table>\n<p>{% endif %}<\/p>\n\n<br>\n\n<div style=\"white-space:nowrap;width:auto;display: flex;gap: 10px;\">\n{%if (vars.steps.Get_File_Reputation_from_VT.data.attributes.signature_info != None and vars.steps.Get_File_Reputation_from_VT.data.attributes.signature_info)%}<div><div class=\"font-size-17 margin-top-12 padding-bottom-md padding-left-sm\"><strong>Signature Information<\/strong><\/div>\n{{vars.steps.Compute_VT_Signature_Info.data}}\n<\/div>{%endif%}\n\n{%if (vars.sandbox_verdict != None and vars.sandbox_verdict) %}\n<div><div class=\"font-size-17 margin-top-12 padding-bottom-md padding-left-sm\"><strong>Sandbox Summary<\/strong><\/div>{{vars.steps.Compute_Sandbox_Verdict_from_VT.data}}\n<\/div>{%endif%}\n<\/div>\n\n\n<div class=\"font-size-17 margin-top-12 padding-bottom-sm padding-left-sm\"><strong>File Basic Properties<\/strong><\/div>\n{{vars.steps.Compute_Basic_Properties.data}}"
                 },
-                "version": "1.0.0",
-                "connector": "alienvault-otx",
-                "operation": "search_pulses",
-                "ignore_errors": true,
-                "operationTitle": "Search Pulses",
-                "step_variables": {
-                    "foundAVReputation": "{{ ( vars.result.data.results and vars.result.data.results|json_query(\"[*].tags[]\") | length > 0 ) | ternary(true,false) }}"
-                }
+                "version": "3.1.2",
+                "connector": "cyops_utilities",
+                "operation": "format_richtext",
+                "operationTitle": "Utils: Format as RichText (Markdown)",
+                "step_variables": []
             },
             "status": null,
-            "top": "270",
-            "left": "3375",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "4cdba82b-984b-4b61-9b3f-b3275f41dbc8"
+            "top": "590",
+            "left": "3700",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "0487d0e4-2ef7-4162-bb2a-d5a047c121d1"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Record",
+            "name": "Upon Create",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Referenced",
+                        "step_iri": "\/api\/3\/workflow_steps\/9726eae1-46ed-4d5e-87eb-24497fa74c7c",
+                        "condition": "{{ vars.input.params['indicator_value'] | length > 0 }}"
+                    },
+                    {
+                        "option": "Upon Create",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/a6f368f3-e0ed-4562-bd00-33719fb02c97"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "350",
+            "left": "5000",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "0f41f3ec-e635-4ca7-a751-9f5940802870"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "indicator_value": "{{vars.input.params['indicator_value'] | ternary(vars.input.params['indicator_value'],vars.input.records[0].value) }}",
+                "reputation_threshold": "5",
+                "foundAnomaliReputation": "false"
+            },
+            "status": null,
+            "top": "270",
+            "left": "1425",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "13fbee17-d1d7-46bd-9b90-4079b7f8b180"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Enrichment Status to In Process",
             "description": null,
             "arguments": {
                 "resource": {
-                    "__link": {
-                        "recordTags": "{% if vars.foundAVReputation %}{{(vars.steps.Get_Reputation_from_AlienVault_OTX.data.results | json_query(\"[*].tags[]\") | unique | string).replace(\"[\",\"\").replace(\"]\",\"\").replace(\"?\",\"\").replace(\"\\'\",\"\").replace(\"#\",\"\").replace(\"\\\"\",\"\").replace(\"\/\",\"\").replace(\"*\",\"\")}}{%endif%}"
-                    },
-                    "reputation": "{{vars.Reputation_Type_IRI}}",
-                    "description": "{{vars.steps.Enrichment_Summary.data['formatted_string']}}\n",
-                    "enrichmentStatus": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0"
+                    "enrichmentStatus": "\/api\/3\/picklists\/8a4609d2-8a3d-4bda-9888-5f00bfea43cb"
                 },
                 "_showJson": false,
-                "operation": "Overwrite",
+                "operation": "Append",
                 "collection": "{{vars.input.records[0]['@id']}}",
                 "__recommend": [],
                 "collectionType": "\/api\/3\/indicators",
@@ -68,10 +98,79 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "430",
-            "left": "5325",
+            "top": "225",
+            "left": "1100",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "a6f368f3-e0ed-4562-bd00-33719fb02c97"
+            "group": null,
+            "uuid": "1aa8de3d-2644-4f82-a4cb-450d24d1391d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Compute Basic Properties",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "data": "{{vars.steps.Get_File_Reputation_from_VT.data.attributes}}",
+                    "styling": true,
+                    "row_fields": "['md5','sha256','sha1','magic','type_tag','type_extension','type_description']",
+                    "table_style": "{ 'width':'auto','font':'10px;'}"
+                },
+                "version": "3.1.2",
+                "connector": "cyops_utilities",
+                "operation": "json_to_html",
+                "operationTitle": "Utils: Convert JSON into a HTML Table",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "590",
+            "left": "2400",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "1ea8327f-275d-495b-9cd6-45dc0353fdb1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Good",
+            "description": null,
+            "arguments": {
+                "Reputation_Type_IRI": "{{(\"IndicatorReputation\" | picklist(\"Good\"))[\"@id\"]}}",
+                "Reputation_Type_Text": "Good"
+            },
+            "status": null,
+            "top": "190",
+            "left": "4350",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "1fcb2eef-d269-4b26-8833-4bcbbfefa41b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get File Reputation from Anomali",
+            "description": null,
+            "arguments": {
+                "name": "Anomali ThreatStream",
+                "config": "8827ae00-b86a-4ed4-aa2c-deae42b1d993",
+                "params": {
+                    "value": "{{vars.indicator_value}}",
+                    "validation": false,
+                    "filter_option": "Exact",
+                    "record_number": "Fetch All Records"
+                },
+                "version": "2.0.0",
+                "connector": "threatstream",
+                "operation": "file_reputation",
+                "ignore_errors": true,
+                "operationTitle": "Get File Reputation",
+                "step_variables": {
+                    "foundAnomaliReputation": "{{ ( vars.result.data.objects and vars.result.data.objects | length > 0 ) | ternary(true,false) }}"
+                }
+            },
+            "status": null,
+            "top": "110",
+            "left": "3375",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "2adf9dbc-1636-44a4-a6e1-d93563569df7"
         },
         {
             "@type": "WorkflowStep",
@@ -84,9 +183,7 @@
                 ],
                 "step_variables": {
                     "input": {
-                        "params": {
-                            "indicator_value": "{{ vars.indicator_value }}"
-                        },
+                        "params": [],
                         "records": [
                             "{{vars.input.records[0]}}"
                         ]
@@ -99,21 +196,11 @@
                     "filters": [
                         {
                             "type": "object",
-                            "field": "typeofindicator",
-                            "value": "\/api\/3\/picklists\/0ca054f2-d923-4992-a4a7-c516e6df281e",
-                            "_value": {
-                                "@id": "\/api\/3\/picklists\/0ca054f2-d923-4992-a4a7-c516e6df281e",
-                                "itemValue": "FileHash-MD5"
-                            },
-                            "operator": "eq"
-                        },
-                        {
-                            "type": "object",
                             "field": "indicatorStatus",
                             "value": "\/api\/3\/picklists\/4218cb58-4de5-4eff-ad08-185d36ef9bab",
                             "_value": {
                                 "@id": "\/api\/3\/picklists\/4218cb58-4de5-4eff-ad08-185d36ef9bab",
-                                "itemValue": "Whitelisted"
+                                "itemValue": "Excluded"
                             },
                             "operator": "neq"
                         },
@@ -142,6 +229,44 @@
                                     "operator": "eq"
                                 }
                             ]
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "type": "object",
+                                    "field": "typeofindicator",
+                                    "value": "\/api\/3\/picklists\/0ca054f2-d923-4992-a4a7-c516e6df281e",
+                                    "_value": {
+                                        "@id": "\/api\/3\/picklists\/0ca054f2-d923-4992-a4a7-c516e6df281e",
+                                        "display": "FileHash-MD5",
+                                        "itemValue": "FileHash-MD5"
+                                    },
+                                    "operator": "eq"
+                                },
+                                {
+                                    "type": "object",
+                                    "field": "typeofindicator",
+                                    "value": "\/api\/3\/picklists\/143e40b0-e643-468d-b968-a542fc85f08d",
+                                    "_value": {
+                                        "@id": "\/api\/3\/picklists\/143e40b0-e643-468d-b968-a542fc85f08d",
+                                        "display": "FileHash-SHA1",
+                                        "itemValue": "FileHash-SHA1"
+                                    },
+                                    "operator": "eq"
+                                },
+                                {
+                                    "type": "object",
+                                    "field": "typeofindicator",
+                                    "value": "\/api\/3\/picklists\/4ea7b083-a0af-41ea-8d7c-7ace16021722",
+                                    "_value": {
+                                        "@id": "\/api\/3\/picklists\/4ea7b083-a0af-41ea-8d7c-7ace16021722",
+                                        "display": "FileHash-SHA256",
+                                        "itemValue": "FileHash-SHA256"
+                                    },
+                                    "operator": "eq"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -150,214 +275,90 @@
             "top": "190",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/ea155646-3821-4542-9702-b246da430a8d",
+            "group": null,
             "uuid": "2b58a2b4-d71e-41d5-9336-d83cb55bcaf3"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Get File Reputation from Symantec Deepsight Intelligence",
+            "name": "Get Reputation from AlienVault OTX",
             "description": null,
             "arguments": {
-                "name": "Symantec DeepSight Intelligence",
-                "config": "8582d1ad-6584-4d14-a0b4-d8571b09b8b2",
+                "name": "AlienVault-OTX",
+                "config": "3d96900a-f870-4ac6-94d0-00865dbaf86f",
                 "params": {
-                    "filehash": "{{vars.indicator_value}}"
+                    "page": 1,
+                    "limit": 5,
+                    "user_text": "{{vars.indicator_value}}"
                 },
-                "version": "1.0.1",
-                "connector": "symantec-deepsight-intelligence",
-                "operation": "filehash_reputation",
+                "version": "1.0.0",
+                "connector": "alienvault-otx",
+                "operation": "search_pulses",
                 "ignore_errors": true,
-                "operationTitle": "Get File Reputation",
+                "operationTitle": "Search Pulses",
                 "step_variables": {
-                    "foundDeepsightReputation": "{{ ( vars.result.data.result and vars.result.data.result.reputation != \"Unknown Reputation\" ) | ternary(true,false) }}"
+                    "foundAVReputation": "{{ ( vars.result.data.results and vars.result.data.results|json_query(\"[*].tags[]\") | length > 0 ) | ternary(true,false) }}"
                 }
             },
             "status": null,
-            "top": "430",
+            "top": "270",
             "left": "3375",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "8de4e8cf-313c-43fc-b2f3-153010e1ca5b"
+            "group": null,
+            "uuid": "4cdba82b-984b-4b61-9b3f-b3275f41dbc8"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Enrichment Summary",
+            "name": "sandbox_detection",
             "description": null,
             "arguments": {
-                "params": {
-                    "value": "{{vars.steps.Compute_VT_Summary.data['formatted_string']}}\n\n{{vars.steps.Compute_Anomali_Summary.data['formatted_string']}}\n\n{{vars.steps.Compute_AV_OTX_Summary.data['formatted_string']}}\n\n {{vars.steps.Compute_Symantec_Summary.data['formatted_string']}}\n\n{{vars.steps.Compute_Additional_Summary.data['formatted_string']}}\n"
-                },
-                "version": "3.1.1",
-                "connector": "cyops_utilities",
-                "operation": "format_richtext",
-                "operationTitle": "Utils: Format as RichText",
-                "step_variables": []
+                "sandbox_detection_VT": "{%if vars.steps.Get_File_Reputation_from_VT.data.attributes.sandbox_verdicts%}\n{% for key,value in vars.steps.Get_File_Reputation_from_VT.data.attributes.sandbox_verdicts.items() %}{{vars.sandbox_verdict.append(value)}}\n{%endfor%}\n{%endif%}"
             },
             "status": null,
-            "top": "350",
-            "left": "4675",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "uuid": "cc6b1155-ac99-4c04-8ee9-8279ea1d48ac"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Configuration",
-            "description": null,
-            "arguments": {
-                "indicator_value": "{{vars.input.params['indicator_value'] | ternary(vars.input.params['indicator_value'],vars.input.records[0].value) }}",
-                "reputation_threshold": "5",
-                "foundAnomaliReputation": "false"
-            },
-            "status": null,
-            "top": "270",
-            "left": "1425",
+            "top": "590",
+            "left": "3050",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "uuid": "13fbee17-d1d7-46bd-9b90-4079b7f8b180"
+            "group": null,
+            "uuid": "510c5dd6-7153-48fb-a16d-3df6d3a5e3c1"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Compute Symantec Summary",
+            "name": "Set Suspicious",
             "description": null,
             "arguments": {
-                "params": {
-                    "value": "<p>{% if vars.foundDeepsightReputation%}<\/p>\n<div class=\"font-size-17 ng-binding padding-left-sm\"><strong>Symantec Deepsight Intelligence<\/strong><\/div>\n\n<div class=\"card-container-body\" style=\"width: 200px;\">\n<div class=\"card-number padding-top-sm padding-bottom-sm\">\n <div class=\"line-height-1\"> <a href=\"https:\/\/mss.symantec.com\/PortalNextgen\/Research\/md5?Hash={{vars.indicator_value}}\" target=\"_blank\" rel=\"noopener noreferrer\"> <span class=\"card-count\">{{vars.steps.Get_File_Reputation_from_Symantec_Deepsight_Intelligence.data.result.reputation}}<\/span> <\/a>\n<div class=\"font-size-14 font-weight-normall padding-top-sm padding-bottom-sm\">Detection: {{vars.steps.Get_File_Reputation_from_Symantec_Deepsight_Intelligence.data.result.detectionName}}<\/div>\n<\/div>\n<\/div>\n<p>{% endif %}<\/p>"
-                },
-                "version": "3.0.3",
-                "connector": "cyops_utilities",
-                "operation": "format_richtext",
-                "operationTitle": "Utils: Format as RichText",
-                "step_variables": []
+                "Reputation_Type_IRI": "{{(\"IndicatorReputation\" | picklist(\"Suspicious\"))[\"@id\"]}}",
+                "Reputation_Type_Text": "Suspicious"
             },
             "status": null,
-            "top": "430",
-            "left": "3700",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "uuid": "a5fd24e0-ab34-4020-9d07-32d0fcb5d22a"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Compute AV OTX Summary",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "value": "{% if vars.foundAVReputation %}\n<div class=\"font-size-11 ng-binding padding-bottom-sm\"><h4 style=\"background: #404142;padding: 5px;text-align: left;color: orange;background: black;\">Alien Vault Summary<\/h4><\/div>\n<table style=\"width: 506px; border-color: #ffffff;\" border=\"1\">\n<tbody>\n<tr>\n<td style=\"width: 45px;font-size:16px;font-weight: normal\"><strong>Tags<\/strong><\/td>\n<td><div class=\"font-size-14 font-weight-normal\">{{(vars.steps.Get_Reputation_from_AlienVault_OTX.data.results | json_query(\"[*].tags[]\") | unique | string).replace(\"[\",\"\").replace(\"]\",\"\")}}<\/div><\/td>\n<\/tr>\n<\/tbody>\n<\/table>\n<p>{% endif %}<\/p>"
-                },
-                "version": "3.1.1",
-                "connector": "cyops_utilities",
-                "operation": "format_richtext",
-                "operationTitle": "Utils: Format as RichText",
-                "step_variables": []
-            },
-            "status": null,
-            "top": "270",
-            "left": "3700",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "uuid": "856cc5cb-3fc2-4b8d-9998-ef35cffded9c"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Compute Anomali Summary",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "value": "<p>{% if vars.foundAnomaliReputation %}<\/p>\n<div class=\"font-size-11 ng-binding padding-bottom-sm\"><h4 style=\"background: #404142;padding: 5px;text-align: left;color: orange;background: black;\"> Anomali Threatstream Detection Summary<\/h4><\/div>\n<div class=\"card-container-body\" style=\"width: 170px;\">\n{%if vars.steps.Get_File_Reputation_from_Anomali.data.objects[0].threatscore !=0 %}\n<div class=\"card-number padding-top-sm padding-bottom-sm\" style=\" border-left: 5px solid red;background:#141b23\">\n <div class=\"line-height-1\"><a href=\"https:\/\/ui.threatstream.com\/detail\/domain\/{{vars.indicator_value}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"font-size-8em\"> <span class=\"card-count\">{{vars.steps.Get_File_Reputation_from_Anomali.data.objects[0].threatscore}} <\/span> <\/a>\n<div class=\"font-size-14 font-weight-normall padding-top-sm padding-bottom-sm\">Severity: {{vars.steps.Get_File_Reputation_from_Anomali.data.objects[0].meta.severity}}<\/div>\n{%else%}\n<div class=\"card-number padding-top-sm padding-bottom-sm\" style=\" border-left: 5px solid red\">\n <div class=\"line-height-1\"><a href=\"https:\/\/ui.threatstream.com\/detail\/domain\/{{vars.indicator_value}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"font-size-8em\"> <span class=\"card-count\">{{vars.steps.Get_File_Reputation_from_Anomali.data.objects[0].threatscore}} <\/span> <\/a>\n<div class=\"font-size-14 font-weight-normall padding-top-sm padding-bottom-sm\">Severity: {{vars.steps.Get_File_Reputation_from_Anomali.data.objects[0].meta.severity}}{% endif %}\n<\/div>\n\n<\/div>\n<\/div>\n<p>{% endif %}<\/p>\n"
-                },
-                "version": "3.1.1",
-                "connector": "cyops_utilities",
-                "operation": "format_richtext",
-                "operationTitle": "Utils: Format as RichText",
-                "step_variables": []
-            },
-            "status": null,
-            "top": "110",
-            "left": "3700",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "uuid": "8cd4cbb8-32a7-4377-852d-d9b17f68a9e1"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Summary",
-            "description": null,
-            "arguments": {
-                "reputation": "{{vars.Reputation_Type_Text}}",
-                "reputation_iri": "{{vars.Reputation_Type_IRI}}",
-                "enrichment_summary": "{{vars.steps.Enrichment_Summary.data['formatted_string']}}"
-            },
-            "status": null,
-            "top": "270",
-            "left": "5325",
+            "top": "510",
+            "left": "4350",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "uuid": "9726eae1-46ed-4d5e-87eb-24497fa74c7c"
+            "group": null,
+            "uuid": "5b1f573c-b9b0-48f5-97fe-9f7ed3d83c1a"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Upon Create",
+            "name": "Compute VT Signature Info",
             "description": null,
             "arguments": {
-                "conditions": [
-                    {
-                        "option": "Referenced",
-                        "step_iri": "\/api\/3\/workflow_steps\/9726eae1-46ed-4d5e-87eb-24497fa74c7c",
-                        "condition": "{{ vars.input.params['indicator_value'] | length > 0 }}"
-                    },
-                    {
-                        "option": "Upon Create",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/a6f368f3-e0ed-4562-bd00-33719fb02c97"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "350",
-            "left": "5000",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "0f41f3ec-e635-4ca7-a751-9f5940802870"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Compute VT Summary",
-            "description": null,
-            "arguments": {
+                "when": "{{(vars.steps.Get_File_Reputation_from_VT.data.attributes.signature_info != None and vars.steps.Get_File_Reputation_from_VT.data.attributes.signature_info)}}",
                 "params": {
-                    "value": "<div class=\"font-size-11 ng-binding padding-bottom-sm\"><h4 style=\"background: #404142;padding: 5px;text-align: left;color: orange;background: black;\"> VirusTotal Detection Summary<\/h4><\/div>\n<table style=\"border-color: #04080c;\" border=\"1\" class=\"font-normal\">\n<tr><td style=\"border-color: #04080c;\">\n<table style=\"color:white;font-size:11;\" class=\"no-border\" >\n<tr>\n<td>\n<html>\n  <head>\n    <title>Title of the document<\/title>\n    <style>\n      span.circle {\n        background: #2f3f51;\n        border-radius: 50%;\n        -moz-border-radius: 50%;\n        -webkit-border-radius: 50%;\n        display: inline-block;\n         font-weight: bold;\n        line-height: 100px;\n        margin-right: 5px;\n        text-align: center;\n        width: 100px;\n      font-size:15px;\n     border-color: Black;\n      }\n    <\/style>\n  <\/head>\n  <body><span class=\"circle\"><i style=\"font-size:25px;color:red \">\n   {{vars.last_analysis_stats.malicious}}<\/i>\/{{(vars.last_analysis_stats.values() | list ) [0:6] | sum}}<\/span>\n  <\/body>\n<\/html>\n<\/td>\n\n<td>\n<div class=\"font-size-14 ng-binding\">Malicious<\/div>\n<div class=\"card-container-body\" style=\"width: 100px;font-size:46px;\">\n<div class=\"card-number\"; style=\"font-size:45px;  border-left: 5px solid red;background:#141b23\">{{vars.last_analysis_stats.malicious}}<\/div>\n<\/div>\n<\/td>\n<td>\n<div class=\"font-size-14 ng-binding\">Suspicious<\/div>\n<div class=\"card-container-body\" style=\"width: 100px;\">\n<div class=\"card-number\" style=\"font-size:45px;  border-left: 5px solid orange; background:#141b23\">{{vars.last_analysis_stats.suspicious}}<\/div>\n<\/div>\n<\/td>\n<td>\n<div class=\"font-size-14 ng-binding\">Harmless<\/div>\n<div class=\"card-container-body\" style=\"width: 100px;\">\n<div class=\"card-number\" style=\"font-size:45px;  border-left: 5px solid green; background:#141b23\">{{vars.last_analysis_stats.harmless}}<\/div><\/div>\n<\/td>\n<\/tr>\n<\/table>\n\n<td style=\"vertical-align:top; border-color: #04080c;\">\n<table style=\"background-color: #1b2430; color:white;font-size:16;\" class=\"margin-10 no-border\">\n<tr>\n<div class=\"margin-top-md\">\n<i class=\"fa fa-group margin-left-md margin-right-sm\"><\/i> Community Votes<\/div>\n\n<td style=\"width: 100px;text-align: center;background:#141b23\">\n<i class=\"\tfa fa-thumbs-o-up\" style=\"font-size:25px;color:green\"><\/i>\n<div class=\"font-size-11 ng-binding\">Harmless {{vars.community_votes.harmless}}<\/div>\n<\/td>\n<td style=\"width: 100px;text-align: center;background:#141b23\">\n<i class=\"fa fa-thumbs-o-down\" style=\"font-size:25px;color:red \"><\/i>\n<div class=\"font-size-11 ng-binding\">Malicious {{vars.community_votes.malicious}}<\/div>\n<\/td>\n<\/tr>\n<\/table>\n<\/div>\n<\/td>\n<\/tr>\n<\/table>"
+                    "data": "{{vars.steps.Get_File_Reputation_from_VT.data.attributes.signature_info}}",
+                    "styling": true,
+                    "row_fields": "",
+                    "table_style": "{ 'width':'auto','font':'10px;'}"
                 },
-                "version": "3.1.1",
+                "version": "3.1.2",
                 "connector": "cyops_utilities",
-                "operation": "format_richtext",
-                "operationTitle": "Utils: Format as RichText",
+                "operation": "json_to_html",
+                "operationTitle": "Utils: Convert JSON into a HTML Table",
                 "step_variables": []
             },
             "status": null,
             "top": "590",
-            "left": "2075",
+            "left": "2725",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "uuid": "bbe818e8-e637-4ade-8556-74d055846618"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get File Reputation from Anomali",
-            "description": null,
-            "arguments": {
-                "name": "Anomali ThreatStream",
-                "config": "8827ae00-b86a-4ed4-aa2c-deae42b1d993",
-                "params": {
-                    "value": "{{vars.indicator_value}}",
-                    "validation": false,
-                    "filter_option": "Exact",
-                    "record_number": "Fetch All Records"
-                },
-                "version": "2.0.0",
-                "connector": "threatstream",
-                "operation": "file_reputation",
-                "ignore_errors": true,
-                "operationTitle": "Get File Reputation",
-                "step_variables": {
-                    "foundAnomaliReputation": "{{ ( vars.result.data.objects and vars.result.data.objects | length > 0 ) | ternary(true,false) }}"
-                }
-            },
-            "status": null,
-            "top": "110",
-            "left": "3375",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "2adf9dbc-1636-44a4-a6e1-d93563569df7"
+            "group": null,
+            "uuid": "5e79b33a-df27-4dbd-b8d8-7c43ae8d7a3f"
         },
         {
             "@type": "WorkflowStep",
@@ -385,130 +386,76 @@
             "top": "590",
             "left": "1750",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
             "uuid": "62c6a052-4d35-4a6c-98e8-70e4606aa27a"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Set Suspicious",
-            "description": null,
-            "arguments": {
-                "Reputation_Type_IRI": "{{(\"IndicatorReputation\" | picklist(\"Suspicious\"))[\"@id\"]}}",
-                "Reputation_Type_Text": "Suspicious"
-            },
-            "status": null,
-            "top": "510",
-            "left": "4350",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "uuid": "5b1f573c-b9b0-48f5-97fe-9f7ed3d83c1a"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set No Reputation",
-            "description": null,
-            "arguments": {
-                "Reputation_Type_IRI": "{{(\"IndicatorReputation\" | picklist(\"No Reputation Available\"))[\"@id\"]}}",
-                "Reputation_Type_Text": "No Reputation Available"
-            },
-            "status": null,
-            "top": "350",
-            "left": "4350",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "uuid": "f113e632-848e-4448-b401-ffa4d09f7d24"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Good",
-            "description": null,
-            "arguments": {
-                "Reputation_Type_IRI": "{{(\"IndicatorReputation\" | picklist(\"Good\"))[\"@id\"]}}",
-                "Reputation_Type_Text": "Good"
-            },
-            "status": null,
-            "top": "190",
-            "left": "4350",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "uuid": "1fcb2eef-d269-4b26-8833-4bcbbfefa41b"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Malicious",
-            "description": null,
-            "arguments": {
-                "Reputation_Type_IRI": "{{(\"IndicatorReputation\" | picklist(\"Malicious\"))[\"@id\"]}}",
-                "Reputation_Type_Text": "Malicious"
-            },
-            "status": null,
-            "top": "30",
-            "left": "4350",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "uuid": "e051b5e4-24c3-41fe-aca6-8f5a283145fc"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Compute Basic Properties",
+            "name": "Compute AV OTX Summary",
             "description": null,
             "arguments": {
                 "params": {
-                    "data": "{{vars.steps.Get_File_Reputation_from_VT.data.attributes}}",
-                    "styling": true,
-                    "row_fields": "['md5','sha256','sha1','magic','type_tag','type_extension','type_description']",
-                    "table_style": "{ 'width':'auto','font':'10px;'}"
+                    "value": "{% if vars.foundAVReputation %}\n<div class=\"font-size-11 ng-binding padding-bottom-sm\"><h4 style=\"background: #404142;padding: 5px;text-align: left;color: orange;background: black;\">Alien Vault Summary<\/h4><\/div>\n<table style=\"width: 506px; border-color: #ffffff;\" border=\"1\">\n<tbody>\n<tr>\n<td style=\"width: 45px;font-size:16px;font-weight: normal\"><strong>Tags<\/strong><\/td>\n<td><div class=\"font-size-14 font-weight-normal\">{{(vars.steps.Get_Reputation_from_AlienVault_OTX.data.results | json_query(\"[*].tags[]\") | unique | string).replace(\"[\",\"\").replace(\"]\",\"\")}}<\/div><\/td>\n<\/tr>\n<\/tbody>\n<\/table>\n<p>{% endif %}<\/p>"
                 },
-                "version": "3.1.2",
-                "connector": "cyops_utilities",
-                "operation": "json_to_html",
-                "operationTitle": "Utils: Convert JSON into a HTML Table",
-                "step_variables": []
-            },
-            "status": null,
-            "top": "590",
-            "left": "2400",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "uuid": "1ea8327f-275d-495b-9cd6-45dc0353fdb1"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Compute Additional Summary",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "value": "<div class=\"font-size-11 ng-binding padding-bottom-sm\"><h4 style=\"background: #404142;padding: 5px;text-align: left;color: orange;background: black;\"> Additional Information<\/h4><\/div>\n\n<p>{% if (vars.tags | length > 0) %}<\/p>\n<div class=\"font-size-17 margin-top-12 padding-bottom-sm padding-left-sm padding-bottom-lg\"><strong>Virustotal Tags<\/strong><\/div>\n<table style=\"width: 506px; border-color: #ffffff;\" border=\"1\">\n<tbody>\n<tr>\n<td style=\"width: 45px;font-size:16px;font-weight: normal\"><strong>Tags<\/strong><\/td>\n<td> <div class=\"font-size-14 font-weight-normal\">{{(vars.tags| string).replace(\"(\",\"\").replace(\")\",\"\")}}<\/div><\/td>\n<\/tr>\n<\/tbody>\n<\/table>\n<p>{% endif %}<\/p>\n\n<br>\n\n<div style=\"white-space:nowrap;width:auto;display: flex;gap: 10px;\">\n{%if (vars.steps.Get_File_Reputation_from_VT.data.attributes.signature_info != None and vars.steps.Get_File_Reputation_from_VT.data.attributes.signature_info)%}<div><div class=\"font-size-17 margin-top-12 padding-bottom-md padding-left-sm\"><strong>Signature Information<\/strong><\/div>\n{{vars.steps.Compute_VT_Signature_Info.data}}\n<\/div>{%endif%}\n\n{%if (vars.sandbox_verdict != None and vars.sandbox_verdict) %}\n<div><div class=\"font-size-17 margin-top-12 padding-bottom-md padding-left-sm\"><strong>Sandbox Summary<\/strong><\/div>{{vars.steps.Compute_Sandbox_Verdict_from_VT.data}}\n<\/div>{%endif%}\n<\/div>\n\n\n<div class=\"font-size-17 margin-top-12 padding-bottom-sm padding-left-sm\"><strong>File Basic Properties<\/strong><\/div>\n{{vars.steps.Compute_Basic_Properties.data}}"
-                },
-                "version": "3.1.2",
+                "version": "3.1.1",
                 "connector": "cyops_utilities",
                 "operation": "format_richtext",
-                "operationTitle": "Utils: Format as RichText (Markdown)",
+                "operationTitle": "Utils: Format as RichText",
                 "step_variables": []
             },
             "status": null,
-            "top": "590",
+            "top": "270",
             "left": "3700",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "uuid": "0487d0e4-2ef7-4162-bb2a-d5a047c121d1"
+            "group": null,
+            "uuid": "856cc5cb-3fc2-4b8d-9998-ef35cffded9c"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Compute VT Signature Info",
+            "name": "Compute Anomali Summary",
             "description": null,
             "arguments": {
-                "when": "{{(vars.steps.Get_File_Reputation_from_VT.data.attributes.signature_info != None and vars.steps.Get_File_Reputation_from_VT.data.attributes.signature_info)}}",
                 "params": {
-                    "data": "{{vars.steps.Get_File_Reputation_from_VT.data.attributes.signature_info}}",
-                    "styling": true,
-                    "row_fields": "",
-                    "table_style": "{ 'width':'auto','font':'10px;'}"
+                    "value": "<p>{% if vars.foundAnomaliReputation %}<\/p>\n<div class=\"font-size-11 ng-binding padding-bottom-sm\"><h4 style=\"background: #404142;padding: 5px;text-align: left;color: orange;background: black;\"> Anomali Threatstream Detection Summary<\/h4><\/div>\n<div class=\"card-container-body\" style=\"width: 170px;\">\n{%if vars.steps.Get_File_Reputation_from_Anomali.data.objects[0].threatscore !=0 %}\n<div class=\"card-number padding-top-sm padding-bottom-sm\" style=\" border-left: 5px solid red;background:#141b23\">\n <div class=\"line-height-1\"><a href=\"https:\/\/ui.threatstream.com\/detail\/domain\/{{vars.indicator_value}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"font-size-8em\"> <span class=\"card-count\">{{vars.steps.Get_File_Reputation_from_Anomali.data.objects[0].threatscore}} <\/span> <\/a>\n<div class=\"font-size-14 font-weight-normall padding-top-sm padding-bottom-sm\">Severity: {{vars.steps.Get_File_Reputation_from_Anomali.data.objects[0].meta.severity}}<\/div>\n{%else%}\n<div class=\"card-number padding-top-sm padding-bottom-sm\" style=\" border-left: 5px solid red\">\n <div class=\"line-height-1\"><a href=\"https:\/\/ui.threatstream.com\/detail\/domain\/{{vars.indicator_value}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"font-size-8em\"> <span class=\"card-count\">{{vars.steps.Get_File_Reputation_from_Anomali.data.objects[0].threatscore}} <\/span> <\/a>\n<div class=\"font-size-14 font-weight-normall padding-top-sm padding-bottom-sm\">Severity: {{vars.steps.Get_File_Reputation_from_Anomali.data.objects[0].meta.severity}}{% endif %}\n<\/div>\n\n<\/div>\n<\/div>\n<p>{% endif %}<\/p>\n"
                 },
-                "version": "3.1.2",
+                "version": "3.1.1",
                 "connector": "cyops_utilities",
-                "operation": "json_to_html",
-                "operationTitle": "Utils: Convert JSON into a HTML Table",
+                "operation": "format_richtext",
+                "operationTitle": "Utils: Format as RichText",
                 "step_variables": []
             },
             "status": null,
-            "top": "590",
-            "left": "2725",
+            "top": "110",
+            "left": "3700",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "uuid": "5e79b33a-df27-4dbd-b8d8-7c43ae8d7a3f"
+            "group": null,
+            "uuid": "8cd4cbb8-32a7-4377-852d-d9b17f68a9e1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get File Reputation from Symantec Deepsight Intelligence",
+            "description": null,
+            "arguments": {
+                "name": "Symantec DeepSight Intelligence",
+                "config": "8582d1ad-6584-4d14-a0b4-d8571b09b8b2",
+                "params": {
+                    "filehash": "{{vars.indicator_value}}"
+                },
+                "version": "1.0.1",
+                "connector": "symantec-deepsight-intelligence",
+                "operation": "filehash_reputation",
+                "ignore_errors": true,
+                "operationTitle": "Get File Reputation",
+                "step_variables": {
+                    "foundDeepsightReputation": "{{ ( vars.result.data.result and vars.result.data.result.reputation != \"Unknown Reputation\" ) | ternary(true,false) }}"
+                }
+            },
+            "status": null,
+            "top": "430",
+            "left": "3375",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "8de4e8cf-313c-43fc-b2f3-153010e1ca5b"
         },
         {
             "@type": "WorkflowStep",
@@ -533,20 +480,115 @@
             "top": "590",
             "left": "3375",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
             "uuid": "955ca14a-5dfb-4b13-97c5-642cc21169b5"
         },
         {
             "@type": "WorkflowStep",
-            "name": "sandbox_detection",
+            "name": "Summary",
             "description": null,
             "arguments": {
-                "sandbox_detection_VT": "{%if vars.steps.Get_File_Reputation_from_VT.data.attributes.sandbox_verdicts%}\n{% for key,value in vars.steps.Get_File_Reputation_from_VT.data.attributes.sandbox_verdicts.items() %}{{vars.sandbox_verdict.append(value)}}\n{%endfor%}\n{%endif%}"
+                "reputation": "{{vars.Reputation_Type_Text}}",
+                "reputation_iri": "{{vars.Reputation_Type_IRI}}",
+                "enrichment_summary": "{{vars.steps.Enrichment_Summary.data['formatted_string']}}"
+            },
+            "status": null,
+            "top": "270",
+            "left": "5325",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "9726eae1-46ed-4d5e-87eb-24497fa74c7c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Compute Symantec Summary",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "value": "<p>{% if vars.foundDeepsightReputation%}<\/p>\n<div class=\"font-size-17 ng-binding padding-left-sm\"><strong>Symantec Deepsight Intelligence<\/strong><\/div>\n\n<div class=\"card-container-body\" style=\"width: 200px;\">\n<div class=\"card-number padding-top-sm padding-bottom-sm\">\n <div class=\"line-height-1\"> <a href=\"https:\/\/mss.symantec.com\/PortalNextgen\/Research\/md5?Hash={{vars.indicator_value}}\" target=\"_blank\" rel=\"noopener noreferrer\"> <span class=\"card-count\">{{vars.steps.Get_File_Reputation_from_Symantec_Deepsight_Intelligence.data.result.reputation}}<\/span> <\/a>\n<div class=\"font-size-14 font-weight-normall padding-top-sm padding-bottom-sm\">Detection: {{vars.steps.Get_File_Reputation_from_Symantec_Deepsight_Intelligence.data.result.detectionName}}<\/div>\n<\/div>\n<\/div>\n<p>{% endif %}<\/p>"
+                },
+                "version": "3.0.3",
+                "connector": "cyops_utilities",
+                "operation": "format_richtext",
+                "operationTitle": "Utils: Format as RichText",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "430",
+            "left": "3700",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "a5fd24e0-ab34-4020-9d07-32d0fcb5d22a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Record",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "__link": {
+                        "recordTags": "{% if vars.foundAVReputation %}{{(vars.steps.Get_Reputation_from_AlienVault_OTX.data.results | json_query(\"[*].tags[]\") | unique | string).replace(\"[\",\"\").replace(\"]\",\"\").replace(\"?\",\"\").replace(\"\\'\",\"\").replace(\"#\",\"\").replace(\"\\\"\",\"\").replace(\"\/\",\"\").replace(\"*\",\"\")}}{%endif%}"
+                    },
+                    "reputation": "{{vars.Reputation_Type_IRI}}",
+                    "description": "{{vars.steps.Enrichment_Summary.data['formatted_string']}}\n",
+                    "enrichmentStatus": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/indicators",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "430",
+            "left": "5325",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "a6f368f3-e0ed-4562-bd00-33719fb02c97"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Exit",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.2.1",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "110",
+            "left": "775",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "b90120da-c735-4729-9a5e-8f22b8816730"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Compute VT Summary",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "value": "<div class=\"font-size-11 ng-binding padding-bottom-sm\"><h4 style=\"background: #404142;padding: 5px;text-align: left;color: orange;background: black;\"> VirusTotal Detection Summary<\/h4><\/div>\n<table style=\"border-color: #04080c;\" border=\"1\" class=\"font-normal\">\n<tr><td style=\"border-color: #04080c;\">\n<table style=\"color:white;font-size:11;\" class=\"no-border\" >\n<tr>\n<td>\n<html>\n  <head>\n    <title>Title of the document<\/title>\n    <style>\n      span.circle {\n        background: #2f3f51;\n        border-radius: 50%;\n        -moz-border-radius: 50%;\n        -webkit-border-radius: 50%;\n        display: inline-block;\n         font-weight: bold;\n        line-height: 100px;\n        margin-right: 5px;\n        text-align: center;\n        width: 100px;\n      font-size:15px;\n     border-color: Black;\n      }\n    <\/style>\n  <\/head>\n  <body><span class=\"circle\"><i style=\"font-size:25px;color:red \">\n   {{vars.last_analysis_stats.malicious}}<\/i>\/{{(vars.last_analysis_stats.values() | list ) [0:6] | sum}}<\/span>\n  <\/body>\n<\/html>\n<\/td>\n\n<td>\n<div class=\"font-size-14 ng-binding\">Malicious<\/div>\n<div class=\"card-container-body\" style=\"width: 100px;font-size:46px;\">\n<div class=\"card-number\"; style=\"font-size:45px;  border-left: 5px solid red;background:#141b23\">{{vars.last_analysis_stats.malicious}}<\/div>\n<\/div>\n<\/td>\n<td>\n<div class=\"font-size-14 ng-binding\">Suspicious<\/div>\n<div class=\"card-container-body\" style=\"width: 100px;\">\n<div class=\"card-number\" style=\"font-size:45px;  border-left: 5px solid orange; background:#141b23\">{{vars.last_analysis_stats.suspicious}}<\/div>\n<\/div>\n<\/td>\n<td>\n<div class=\"font-size-14 ng-binding\">Harmless<\/div>\n<div class=\"card-container-body\" style=\"width: 100px;\">\n<div class=\"card-number\" style=\"font-size:45px;  border-left: 5px solid green; background:#141b23\">{{vars.last_analysis_stats.harmless}}<\/div><\/div>\n<\/td>\n<\/tr>\n<\/table>\n\n<td style=\"vertical-align:top; border-color: #04080c;\">\n<table style=\"background-color: #1b2430; color:white;font-size:16;\" class=\"margin-10 no-border\">\n<tr>\n<div class=\"margin-top-md\">\n<i class=\"fa fa-group margin-left-md margin-right-sm\"><\/i> Community Votes<\/div>\n\n<td style=\"width: 100px;text-align: center;background:#141b23\">\n<i class=\"\tfa fa-thumbs-o-up\" style=\"font-size:25px;color:green\"><\/i>\n<div class=\"font-size-11 ng-binding\">Harmless {{vars.community_votes.harmless}}<\/div>\n<\/td>\n<td style=\"width: 100px;text-align: center;background:#141b23\">\n<i class=\"fa fa-thumbs-o-down\" style=\"font-size:25px;color:red \"><\/i>\n<div class=\"font-size-11 ng-binding\">Malicious {{vars.community_votes.malicious}}<\/div>\n<\/td>\n<\/tr>\n<\/table>\n<\/div>\n<\/td>\n<\/tr>\n<\/table>"
+                },
+                "version": "3.1.1",
+                "connector": "cyops_utilities",
+                "operation": "format_richtext",
+                "operationTitle": "Utils: Format as RichText",
+                "step_variables": []
             },
             "status": null,
             "top": "590",
-            "left": "3050",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "uuid": "510c5dd6-7153-48fb-a16d-3df6d3a5e3c1"
+            "left": "2075",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "bbe818e8-e637-4ade-8556-74d055846618"
         },
         {
             "@type": "WorkflowStep",
@@ -572,25 +614,29 @@
             "top": "190",
             "left": "450",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
             "uuid": "c496266e-7ef9-48d8-a58f-28e7ac636bf1"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Exit",
+            "name": "Enrichment Summary",
             "description": null,
             "arguments": {
-                "params": [],
-                "version": "3.2.1",
+                "params": {
+                    "value": "{{vars.steps.Compute_VT_Summary.data['formatted_string']}}\n\n{{vars.steps.Compute_Anomali_Summary.data['formatted_string']}}\n\n{{vars.steps.Compute_AV_OTX_Summary.data['formatted_string']}}\n\n {{vars.steps.Compute_Symantec_Summary.data['formatted_string']}}\n\n{{vars.steps.Compute_Additional_Summary.data['formatted_string']}}\n"
+                },
+                "version": "3.1.1",
                 "connector": "cyops_utilities",
-                "operation": "no_op",
-                "operationTitle": "Utils: No Operation",
+                "operation": "format_richtext",
+                "operationTitle": "Utils: Format as RichText",
                 "step_variables": []
             },
             "status": null,
-            "top": "110",
-            "left": "775",
+            "top": "350",
+            "left": "4675",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "uuid": "b90120da-c735-4729-9a5e-8f22b8816730"
+            "group": null,
+            "uuid": "cc6b1155-ac99-4c04-8ee9-8279ea1d48ac"
         },
         {
             "@type": "WorkflowStep",
@@ -628,31 +674,23 @@
             "top": "350",
             "left": "4025",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
             "uuid": "ddaace9e-9664-49ea-a9b4-30c6706302f2"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Enrichment Status to In Process",
+            "name": "Set Malicious",
             "description": null,
             "arguments": {
-                "resource": {
-                    "enrichmentStatus": "\/api\/3\/picklists\/8a4609d2-8a3d-4bda-9888-5f00bfea43cb"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/indicators",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
+                "Reputation_Type_IRI": "{{(\"IndicatorReputation\" | picklist(\"Malicious\"))[\"@id\"]}}",
+                "Reputation_Type_Text": "Malicious"
             },
             "status": null,
-            "top": "225",
-            "left": "1100",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "1aa8de3d-2644-4f82-a4cb-450d24d1391d"
+            "top": "30",
+            "left": "4350",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "e051b5e4-24c3-41fe-aca6-8f5a283145fc"
         },
         {
             "@type": "WorkflowStep",
@@ -678,10 +716,44 @@
             "top": "270",
             "left": "775",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
             "uuid": "eb48e6b0-f9b3-44bc-992e-9500d8c4d5d0"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set No Reputation",
+            "description": null,
+            "arguments": {
+                "Reputation_Type_IRI": "{{(\"IndicatorReputation\" | picklist(\"No Reputation Available\"))[\"@id\"]}}",
+                "Reputation_Type_Text": "No Reputation Available"
+            },
+            "status": null,
+            "top": "350",
+            "left": "4350",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "f113e632-848e-4448-b401-ffa4d09f7d24"
         }
     ],
     "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Reputation from AlienVault OTX -> Copy  of Compute Anomali Summary",
+            "targetStep": "\/api\/3\/workflow_steps\/856cc5cb-3fc2-4b8d-9998-ef35cffded9c",
+            "sourceStep": "\/api\/3\/workflow_steps\/4cdba82b-984b-4b61-9b3f-b3275f41dbc8",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "4f154aba-e2a9-4481-b800-144af3a1cb72"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get File Reputation from Anomali -> Compute Anomali Summary",
+            "targetStep": "\/api\/3\/workflow_steps\/8cd4cbb8-32a7-4377-852d-d9b17f68a9e1",
+            "sourceStep": "\/api\/3\/workflow_steps\/2adf9dbc-1636-44a4-a6e1-d93563569df7",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "e7a04f06-7199-4180-8289-ad19a27cee58"
+        },
         {
             "@type": "WorkflowRoute",
             "name": "Configuration -> Get File Reputation from Anomali",
@@ -717,24 +789,6 @@
             "label": null,
             "isExecuted": false,
             "uuid": "51fc0bf4-261f-4193-90c7-100e448fb46b"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Get Reputation from AlienVault OTX -> Copy  of Compute Anomali Summary",
-            "targetStep": "\/api\/3\/workflow_steps\/856cc5cb-3fc2-4b8d-9998-ef35cffded9c",
-            "sourceStep": "\/api\/3\/workflow_steps\/4cdba82b-984b-4b61-9b3f-b3275f41dbc8",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "4f154aba-e2a9-4481-b800-144af3a1cb72"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Get File Reputation from Anomali -> Compute Anomali Summary",
-            "targetStep": "\/api\/3\/workflow_steps\/8cd4cbb8-32a7-4377-852d-d9b17f68a9e1",
-            "sourceStep": "\/api\/3\/workflow_steps\/2adf9dbc-1636-44a4-a6e1-d93563569df7",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "e7a04f06-7199-4180-8289-ad19a27cee58"
         },
         {
             "@type": "WorkflowRoute",
@@ -989,6 +1043,7 @@
             "uuid": "ab66184f-fe46-4f76-92e8-d77048bf92a2"
         }
     ],
+    "groups": [],
     "priority": null,
     "uuid": "c0ce666f-ba81-4251-a9a3-70cbe2c8afeb",
     "owners": [],


### PR DESCRIPTION
Mantis #0795214

Unit Test Case:

- Modified 'On Create' Trigger condition for '03 - Enrich' > 'Indicator (Type File - MD5) - Get Reputation' 
- Added condition to trigger playbook for Types FileHash-MD5, FileHash-SHA256 and FileHash-SHA1
- Validated playbook execution for IOC Types FileHash-MD5, FileHash-SHA256 and FileHash-SHA1
- The playbook execution was successful

Mantis #0806876

Unit Cases
- Added visibility conditions to the following email related fields in alert mmd
- **Condition:** Following fields should be visible for Alert Type "Phishing" or "Suspicious Email"  and field value is "Not Null"
    * Email Recipients (To)
    * Recipient Email Address
    * Sender Domain
    * Sender Email Address
    * Email
    * Email Body
    * Email From
    * Email Headers
    * Email Subject
    * Reporter Email Body
    * Return Path
    * Reporter

- Validated that all the above-mentioned fields are visible in Alert SVT