### PR TITLE
Modified visibility condition for Email File field

### DIFF
--- a/modules/alerts/mmd.json
+++ b/modules/alerts/mmd.json
@@ -1,6 +1,6 @@
 {
     "@context": "\/api\/3\/contexts\/StagingModelMetadata",
-    "@id": "\/api\/3\/staging_model_metadatas\/c8c8fa5f-4dde-4282-9129-8ec0aa63a045",
+    "@id": "\/api\/3\/staging_model_metadatas\/2086e5d1-ed26-4cab-822b-305a800a85ca",
     "@type": "StagingModelMetadata",
     "type": "alerts",
     "parentType": null,
@@ -3697,6 +3697,66 @@
             }
         },
         {
+            "@id": "\/api\/3\/attribute_metadatas\/409c6293-8528-4450-9ea7-6efe4852a060",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "processGuid",
+            "length": 0,
+            "orderIndex": 70,
+            "formType": "text",
+            "dataSource": [],
+            "searchable": true,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 1024
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "OR",
+                    "filters": [
+                        {
+                            "field": "processGuid",
+                            "operator": "isnull",
+                            "_operator": "isnull",
+                            "value": "false",
+                            "type": "primitive"
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "409c6293-8528-4450-9ea7-6efe4852a060",
+            "displayName": "{{ processGuid }}",
+            "descriptions": {
+                "singular": "Process GUID"
+            }
+        },
+        {
             "@id": "\/api\/3\/attribute_metadatas\/d5789132-d5ad-4588-8410-e64a48fedf65",
             "@type": "AttributeMetadata",
             "type": "string",
@@ -4567,66 +4627,6 @@
             "displayName": "{{ persons }}",
             "descriptions": {
                 "singular": "People"
-            }
-        },
-        {
-            "@id": "\/api\/3\/attribute_metadatas\/409c6293-8528-4450-9ea7-6efe4852a060",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "processGuid",
-            "length": 0,
-            "orderIndex": 70,
-            "formType": "text",
-            "dataSource": [],
-            "searchable": true,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 1024
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "OR",
-                    "filters": [
-                        {
-                            "field": "processGuid",
-                            "operator": "isnull",
-                            "_operator": "isnull",
-                            "value": "false",
-                            "type": "primitive"
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "409c6293-8528-4450-9ea7-6efe4852a060",
-            "displayName": "{{ processGuid }}",
-            "descriptions": {
-                "singular": "Process GUID"
             }
         },
         {
@@ -5739,137 +5739,6 @@
             }
         },
         {
-            "@id": "\/api\/3\/attribute_metadatas\/302a7b25-aafa-4b18-b3b8-6aaf2ea4ace9",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "uuid",
-            "length": 36,
-            "orderIndex": 91,
-            "formType": null,
-            "dataSource": [],
-            "searchable": false,
-            "peerReplicable": true,
-            "system": true,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "required": false,
-                "minlength": 0,
-                "maxlength": 10485761,
-                "_enableRange": false
-            },
-            "bulkAction": {
-                "allow": false
-            },
-            "dataSourceFilters": [],
-            "defaultValue": "",
-            "tooltip": "",
-            "visibility": true,
-            "htmlEscape": false,
-            "orphanRemoval": null,
-            "readable": true,
-            "writeable": true,
-            "identifier": true,
-            "unique": false,
-            "recommend": false,
-            "uuid": "302a7b25-aafa-4b18-b3b8-6aaf2ea4ace9",
-            "displayName": "{{ uuid }}",
-            "descriptions": {
-                "singular": "UUID"
-            }
-        },
-        {
-            "@id": "\/api\/3\/attribute_metadatas\/dc309f27-217c-4f15-b93f-5006cceb37b8",
-            "@type": "AttributeMetadata",
-            "type": "string",
-            "name": "fileEmail",
-            "length": 0,
-            "orderIndex": 46,
-            "formType": "file",
-            "dataSource": {
-                "model": "files"
-            },
-            "searchable": false,
-            "peerReplicable": true,
-            "system": false,
-            "encrypted": false,
-            "gridColumn": false,
-            "collection": false,
-            "inversedField": null,
-            "ownsRelationship": false,
-            "validation": {
-                "_enableRange": false,
-                "required": false,
-                "minlength": 0,
-                "maxlength": 10485761
-            },
-            "bulkAction": {
-                "allow": false,
-                "buttonClass": "btn btn-default btn-sm",
-                "buttonIcon": "",
-                "buttonText": ""
-            },
-            "dataSourceFilters": [],
-            "defaultValue": null,
-            "tooltip": "",
-            "visibility": [
-                {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": [
-                        {
-                            "field": "fileEmail",
-                            "operator": "isnull",
-                            "_operator": "isnull",
-                            "value": "false",
-                            "type": "primitive"
-                        },
-                        {
-                            "logic": "OR",
-                            "filters": [
-                                {
-                                    "field": "type",
-                                    "operator": "eq",
-                                    "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
-                                    "_value": {
-                                        "itemValue": "Suspicious Email",
-                                        "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
-                                    },
-                                    "type": "object"
-                                },
-                                {
-                                    "field": "type",
-                                    "operator": "eq",
-                                    "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
-                                    "_value": {
-                                        "itemValue": "Phishing",
-                                        "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
-                                    },
-                                    "type": "object"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ],
-            "htmlEscape": false,
-            "orphanRemoval": false,
-            "readable": true,
-            "writeable": true,
-            "identifier": false,
-            "unique": false,
-            "recommend": false,
-            "uuid": "dc309f27-217c-4f15-b93f-5006cceb37b8",
-            "displayName": "{{ fileEmail }}",
-            "descriptions": {
-                "singular": "Email"
-            }
-        },
-        {
             "@id": "\/api\/3\/attribute_metadatas\/0f5c023a-dcb8-483f-bfe0-aee854d1c1b9",
             "@type": "AttributeMetadata",
             "type": "string",
@@ -6722,6 +6591,127 @@
             "descriptions": {
                 "singular": "Email Subject"
             }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/302a7b25-aafa-4b18-b3b8-6aaf2ea4ace9",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "uuid",
+            "length": 36,
+            "orderIndex": 91,
+            "formType": null,
+            "dataSource": [],
+            "searchable": false,
+            "peerReplicable": true,
+            "system": true,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761,
+                "_enableRange": false
+            },
+            "bulkAction": {
+                "allow": false
+            },
+            "dataSourceFilters": [],
+            "defaultValue": "",
+            "tooltip": "",
+            "visibility": true,
+            "htmlEscape": false,
+            "orphanRemoval": null,
+            "readable": true,
+            "writeable": true,
+            "identifier": true,
+            "unique": false,
+            "recommend": false,
+            "uuid": "302a7b25-aafa-4b18-b3b8-6aaf2ea4ace9",
+            "displayName": "{{ uuid }}",
+            "descriptions": {
+                "singular": "UUID"
+            }
+        },
+        {
+            "@id": "\/api\/3\/attribute_metadatas\/dc309f27-217c-4f15-b93f-5006cceb37b8",
+            "@type": "AttributeMetadata",
+            "type": "string",
+            "name": "fileEmail",
+            "length": 0,
+            "orderIndex": 46,
+            "formType": "file",
+            "dataSource": {
+                "model": "files"
+            },
+            "searchable": false,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "_enableRange": false,
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonClass": "btn btn-default btn-sm",
+                "buttonIcon": "",
+                "buttonText": ""
+            },
+            "dataSourceFilters": [],
+            "defaultValue": null,
+            "tooltip": "",
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "OR",
+                    "filters": [
+                        {
+                            "field": "type",
+                            "operator": "eq",
+                            "value": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82",
+                            "_value": {
+                                "display": "Suspicious Email",
+                                "itemValue": "Suspicious Email",
+                                "@id": "\/api\/3\/picklists\/c145394b-069a-449b-a05e-67980d0f4b82"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "field": "type",
+                            "operator": "eq",
+                            "value": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                            "_value": {
+                                "display": "Phishing",
+                                "itemValue": "Phishing",
+                                "@id": "\/api\/3\/picklists\/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa"
+                            },
+                            "type": "object"
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": false,
+            "readable": true,
+            "writeable": true,
+            "identifier": false,
+            "unique": false,
+            "recommend": false,
+            "uuid": "dc309f27-217c-4f15-b93f-5006cceb37b8",
+            "displayName": "{{ fileEmail }}",
+            "descriptions": {
+                "singular": "Email"
+            }
         }
     ],
     "system": false,
@@ -6735,7 +6725,7 @@
         "delete_primary_data_after": 60
     },
     "archivalFilters": [],
-    "uuid": "c8c8fa5f-4dde-4282-9129-8ec0aa63a045",
+    "uuid": "2086e5d1-ed26-4cab-822b-305a800a85ca",
     "displayName": "{{ name }}",
     "descriptions": {
         "plural": "Alerts",


### PR DESCRIPTION
Modified visibility condition for Email File field [Mantis #0806876]
- previously the condition was set as "if the field is null and alert type is 'Suspicious Email' or 'Phishing'"
- the `null` condition check has been removed and the field will be now visible when alert type is 'Suspicious Email' or 'Phishing'