### PR TITLE
[#0822634] - Two items from picklist are selected for 'Closure Reason' when we attempt to escalate an alert

### DIFF
--- a/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident.json
+++ b/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident.json
@@ -401,7 +401,7 @@
                         "searchable": false,
                         "templateUrl": "app\/components\/form\/fields\/typeahead.html",
                         "defaultValue": {
-                            "id": "371",
+                            "id": "369",
                             "@id": "\/api\/3\/picklists\/cc2d6b59-62de-4cb6-93a2-bcce4250009d",
                             "icon": null,
                             "uuid": "cc2d6b59-62de-4cb6-93a2-bcce4250009d",


### PR DESCRIPTION
### Description

Two items from picklist are selected for 'Closure Reason' when we attempt to escalate an alert

### Mantis/PMDB Tickets:

https://mantis.fortinet.com/bug_view_page.php?bug_id=0822634

### To Test
- [ ] Run js hint tests
- [ ] Run unit tests
