### PR TITLE
Updated Extract Indicator playbook

### DIFF
--- a/playbooks/03 - Enrich/Extract Indicators.json
+++ b/playbooks/03 - Enrich/Extract Indicators.json
@@ -15,54 +15,8 @@
     "synchronous": false,
     "collection": "\/api\/3\/workflow_collections\/deaa4d19-7444-4f3a-a80e-9577436f25ef",
     "versions": [],
-    "triggerStep": "\/api\/3\/workflow_steps\/0b115b6f-1dd8-49e3-ac26-24eb9ecb242b",
+    "triggerStep": "\/api\/3\/workflow_steps\/c5791d4a-fa1c-41d2-8175-b459c32620e9",
     "steps": [
-        {
-            "@type": "WorkflowStep",
-            "name": "Wait for Enrichment",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.steps.Create_Indicator | length > 0}}",
-                "query": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": [
-                        {
-                            "type": "primitive",
-                            "field": "alerts.id",
-                            "value": "{{vars.input.records[0].id}}",
-                            "operator": "eq",
-                            "_operator": "eq"
-                        },
-                        {
-                            "type": "object",
-                            "field": "reputation",
-                            "value": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
-                            "_value": {
-                                "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
-                                "itemValue": "TBD"
-                            },
-                            "operator": "eq"
-                        }
-                    ]
-                },
-                "module": "indicators?$limit=30",
-                "do_until": {
-                    "delay": 65,
-                    "retries": 2,
-                    "condition": "{{vars.result | length == 0}}"
-                },
-                "checkboxFields": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1520",
-            "left": "120",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
-            "group": null,
-            "uuid": "6387638d-9134-4ecb-a492-fe721b866e7a"
-        },
         {
             "@type": "WorkflowStep",
             "name": "Get Indicators",
@@ -75,100 +29,7 @@
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
-            "uuid": "085701c3-8411-41da-9bc4-86d7ef5660ec"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Indicator List",
-            "description": null,
-            "arguments": {
-                "temp": "{% for key,value in vars.indicator_type_map.items()%}{%if vars.alert_metadata.get(key) %}{% set list_vals = vars.alert_metadata.get(key).split(\",\") %}{%for val in list_vals%}{{vars.alert_field_iocs.append({\"type\": value, \"value\":val})}}{%endfor%}{%endif%}{%endfor%}{{vars.alert_field_iocs}}",
-                "excluded_indicators": "{{vars.ips | union(vars.domains) | union(vars.urls)}}"
-            },
-            "status": null,
-            "top": "435",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "7d4b5714-825d-4abd-a258-18db0cfd3475"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Alert State",
-            "description": null,
-            "arguments": {
-                "resource": {
-                    "state": {
-                        "id": 71,
-                        "@id": "\/api\/3\/picklists\/501d0562-89a0-4079-9a9e-cdde7d34e3ed",
-                        "icon": null,
-                        "@type": "Picklist",
-                        "color": null,
-                        "display": "Indicator Extracted",
-                        "listName": "\/api\/3\/picklist_names\/2f9ed741-25fe-475a-9f12-64336288eebf",
-                        "itemValue": "Indicator Extracted",
-                        "orderIndex": 2
-                    }
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "collectionType": "\/api\/3\/alerts",
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1650",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "group": null,
-            "uuid": "ba6e4c12-47f0-40f3-9ff4-3c16acde7abd"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Unified Email IOCs",
-            "description": null,
-            "arguments": {
-                "_dummy": "{%if vars.email_body_iocs %} \n{%for item in vars.email_body_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%if vars.header_iocs%}\n{%for item in vars.header_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%if vars.description_iocs%}\n{%for item in vars.description_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%if vars.file_hash_iocs %}\n{%for item in vars.file_hash_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%for item in vars.alert_field_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}"
-            },
-            "status": null,
-            "top": "1110",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "971f518b-11b9-432c-ab86-2b9d67c63f20"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Extract Indicators from header",
-            "description": "This is step is specifically designed for 'Suspicious Email' Alert",
-            "arguments": {
-                "name": "CyOps Utilities",
-                "when": "{{vars.input.records[0].returnPath or vars.input.params.alertMetaData.returnPath}}",
-                "params": {
-                    "data": "{{vars.input.params.alertMetaData.returnPath| ternary(vars.input.params.alertMetaData.returnPath,vars.input.records[0].returnPath)}}",
-                    "whitelist": "{{vars.excluded_indicators}}",
-                    "case_sensitive": "",
-                    "override_regex": "",
-                    "private_whitelist": ""
-                },
-                "version": "3.0.3",
-                "connector": "cyops_utilities",
-                "operation": "extract_artifacts",
-                "operationTitle": "CyOPs: Extract Artifacts from string",
-                "step_variables": {
-                    "header_iocs": "{{vars.result.data.results}}"
-                },
-                "operationOutput": []
-            },
-            "status": null,
-            "top": "705",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "group": null,
-            "uuid": "1f26db7b-ace2-4ded-bcd7-43fd4e401d19"
+            "uuid": "e7bbfc81-c4c6-4768-a875-e24d81d30de5"
         },
         {
             "@type": "WorkflowStep",
@@ -213,7 +74,86 @@
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/ea155646-3821-4542-9702-b246da430a8d",
             "group": null,
-            "uuid": "0b115b6f-1dd8-49e3-ac26-24eb9ecb242b"
+            "uuid": "c5791d4a-fa1c-41d2-8175-b459c32620e9"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Extract Indicators from header",
+            "description": "This is step is specifically designed for 'Suspicious Email' Alert",
+            "arguments": {
+                "name": "CyOps Utilities",
+                "when": "{{vars.input.records[0].returnPath or vars.input.params.alertMetaData.returnPath}}",
+                "params": {
+                    "data": "{{vars.input.params.alertMetaData.returnPath| ternary(vars.input.params.alertMetaData.returnPath,vars.input.records[0].returnPath)}}",
+                    "whitelist": "{{vars.excluded_indicators}}",
+                    "case_sensitive": "",
+                    "override_regex": "",
+                    "private_whitelist": ""
+                },
+                "version": "3.0.3",
+                "connector": "cyops_utilities",
+                "operation": "extract_artifacts",
+                "operationTitle": "CyOPs: Extract Artifacts from string",
+                "step_variables": {
+                    "header_iocs": "{{vars.result.data.results}}"
+                },
+                "operationOutput": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "9394cafa-441a-4131-b328-bbd2e3339c12"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": "You can customize extraction by modifying indicator map in configuration step",
+            "arguments": {
+                "ips": "{{globalVars.Excludelist_IPs.split(',')}}",
+                "urls": "{{globalVars.Excludelist_URLs.split(',')}}",
+                "domains": "{{globalVars.Excludelist_Domains.split(',')}}",
+                "alert_iri": "{{vars.input.params.alertMetaData['@id'] | ternary(vars.input.params.alertMetaData['@id'],vars.input.records[0]['@id'])}}",
+                "unified_iocs": "[]",
+                "alert_metadata": "{{vars.input.params.alertMetaData | ternary(vars.input.params.alertMetaData,vars.input.records[0])}}",
+                "alert_field_iocs": "[]",
+                "indicator_type_map": "{{globalVars.Indicator_Type_Map}}",
+                "excluded_indicators": "[]"
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "21ffcc50-7679-4df9-bacb-ad7480c465cd"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Dedicated Tenant Record",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes, Extract at Tenant Node",
+                        "step_iri": "\/api\/3\/workflow_steps\/915e6a13-58cc-435f-9b7e-ed6250393195",
+                        "condition": "{{ 'tenant' in vars.input.records[0] and vars.input.records[0].tenant.isDedicated and vars.input.records[0].tenant.role != 'self' }}",
+                        "step_name": "Exit"
+                    },
+                    {
+                        "option": "No, Extract Here",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/21ffcc50-7679-4df9-bacb-ad7480c465cd",
+                        "step_name": "Configuration"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "165",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "c639685a-e65e-4be4-8fcf-e57613edb51b"
         },
         {
             "@type": "WorkflowStep",
@@ -243,29 +183,172 @@
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
-            "uuid": "46eae51d-e1e1-420f-a8f9-5023687232af"
+            "uuid": "6ea0365a-3a12-495c-82d9-17c787bda75f"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Configuration",
-            "description": "You can customize extraction by modifying indicator map in configuration step",
+            "name": "Wait For Enrichment",
+            "description": null,
             "arguments": {
-                "ips": "{{globalVars.Excludelist_IPs.split(',')}}",
-                "urls": "{{globalVars.Excludelist_URLs.split(',')}}",
-                "domains": "{{globalVars.Excludelist_Domains.split(',')}}",
-                "alert_iri": "{{vars.input.params.alertMetaData['@id'] | ternary(vars.input.params.alertMetaData['@id'],vars.input.records[0]['@id'])}}",
-                "unified_iocs": "[]",
-                "alert_metadata": "{{vars.input.params.alertMetaData | ternary(vars.input.params.alertMetaData,vars.input.records[0])}}",
-                "alert_field_iocs": "[]",
-                "indicator_type_map": "{{globalVars.Indicator_Type_Map}}",
-                "excluded_indicators": "[]"
+                "rule": {
+                    "actions": [
+                        {
+                            "type": "resume_playbook",
+                            "enabled": true,
+                            "channel_uuid": "e2ce87c2-c55a-11ec-9d64-0242ac120002"
+                        }
+                    ],
+                    "is_active": true,
+                    "event_type": "update",
+                    "entity_name": "Indicators",
+                    "entity_type": "indicators",
+                    "event_source": "crudhub",
+                    "trigger_condition": {
+                        "sort": [],
+                        "limit": 30,
+                        "logic": "OR",
+                        "filters": [
+                            {
+                                "logic": "AND",
+                                "filters": [
+                                    {
+                                        "type": "primitive",
+                                        "field": "id",
+                                        "value": "{{vars.item.id}}",
+                                        "operator": "eq",
+                                        "_operator": "eq"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "field": "reputation",
+                                        "value": "",
+                                        "_value": {
+                                            "@id": "",
+                                            "display": "",
+                                            "itemValue": ""
+                                        },
+                                        "operator": "changed"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "field": "reputation",
+                                        "value": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                        "_value": {
+                                            "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                            "itemValue": "TBD"
+                                        },
+                                        "operator": "neq"
+                                    }
+                                ]
+                            },
+                            {
+                                "logic": "AND",
+                                "filters": [
+                                    {
+                                        "type": "primitive",
+                                        "field": "id",
+                                        "value": "{{vars.item.id}}",
+                                        "operator": "eq",
+                                        "_operator": "eq"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "field": "enrichmentStatus",
+                                        "value": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0",
+                                        "_value": {
+                                            "@id": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0",
+                                            "itemValue": "Completed"
+                                        },
+                                        "operator": "eq"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "type": "ConditionBased",
+                "delay": {
+                    "days": 0,
+                    "hours": 0,
+                    "weeks": 0,
+                    "minutes": 0,
+                    "seconds": 0
+                },
+                "for_each": {
+                    "item": "{{vars.steps.Create_Indicator}}",
+                    "condition": ""
+                },
+                "step_variables": []
             },
             "status": null,
-            "top": "300",
+            "top": "1515",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/6832e556-b9c7-497a-babe-feda3bd27dbf",
+            "group": null,
+            "uuid": "925de451-5069-41a6-9a5b-ec1a9b071d71"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Indicator List",
+            "description": null,
+            "arguments": {
+                "temp": "{% for key,value in vars.indicator_type_map.items()%}{%if vars.alert_metadata.get(key) %}{% set list_vals = vars.alert_metadata.get(key).split(\",\") %}{%for val in list_vals%}{{vars.alert_field_iocs.append({\"type\": value, \"value\":val})}}{%endfor%}{%endif%}{%endfor%}{{vars.alert_field_iocs}}",
+                "excluded_indicators": "{{vars.ips | union(vars.domains) | union(vars.urls)}}"
+            },
+            "status": null,
+            "top": "435",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
-            "uuid": "2fcbe2aa-1531-4947-8de8-03e733d545b2"
+            "uuid": "b31ff3b1-db1b-4b2d-b170-ebe51e2a63c7"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Unified Email IOCs",
+            "description": null,
+            "arguments": {
+                "_dummy": "{%if vars.email_body_iocs %} \n{%for item in vars.email_body_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%if vars.header_iocs%}\n{%for item in vars.header_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%if vars.description_iocs%}\n{%for item in vars.description_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%if vars.file_hash_iocs %}\n{%for item in vars.file_hash_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%for item in vars.alert_field_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}"
+            },
+            "status": null,
+            "top": "1110",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "79976d9e-2f2b-43c1-87a1-76db28946e0e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Alert State",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "state": {
+                        "id": 71,
+                        "@id": "\/api\/3\/picklists\/501d0562-89a0-4079-9a9e-cdde7d34e3ed",
+                        "icon": null,
+                        "@type": "Picklist",
+                        "color": null,
+                        "display": "Indicator Extracted",
+                        "listName": "\/api\/3\/picklist_names\/2f9ed741-25fe-475a-9f12-64336288eebf",
+                        "itemValue": "Indicator Extracted",
+                        "orderIndex": 2
+                    }
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "collectionType": "\/api\/3\/alerts",
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1650",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "1c47615b-90b3-439d-9d45-eb29b14064ed"
         },
         {
             "@type": "WorkflowStep",
@@ -290,7 +373,12 @@
                     "expiryDate": "{{arrow.utcnow().shift(days=+(globalVars.Default_Indicator_TTL_Days | int)).timestamp}}",
                     "expiredStatus": "\/api\/3\/picklists\/d4ca4a72-7974-4b93-843e-da9efa235c6e",
                     "indicatorStatus": "\/api\/3\/picklists\/2f5cff61-fbff-4bb3-96be-302b78a9fb47",
-                    "typeofindicator": "{{('IndicatorType' | picklist(vars.item.type))['@id']}}"
+                    "typeofindicator": "{{('IndicatorType' | picklist(vars.item.type))['@id']}}",
+                    "__fieldsToUpdate": [
+                        "alerts",
+                        "lastSeen"
+                    ],
+                    "enrichmentStatus": "\/api\/3\/picklists\/a6d9da29-27b1-4b8a-965d-8d91518540d5"
                 },
                 "_showJson": false,
                 "operation": "Append",
@@ -306,48 +394,7 @@
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
-            "uuid": "c9057eb9-06a7-4b9c-a2d6-4f7f16ae54a0"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Removing NULL Indicators",
-            "description": "Removing null indicators extracted from email",
-            "arguments": {
-                "unified_iocs": "{{ vars.unified_iocs | json_query('[?value != null]') }}"
-            },
-            "status": null,
-            "top": "1245",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "f0e42b54-be9f-4333-b881-20b73aade2f7"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Is Dedicated Tenant Record",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Yes, Extract at Tenant Node",
-                        "step_iri": "\/api\/3\/workflow_steps\/d3f73ed3-d9c9-40a1-8262-d41d2f0d82ba",
-                        "condition": "{{ 'tenant' in vars.input.records[0] and vars.input.records[0].tenant.isDedicated and vars.input.records[0].tenant.role != 'self' }}",
-                        "step_name": "Exit"
-                    },
-                    {
-                        "option": "No, Extract Here",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/2fcbe2aa-1531-4947-8de8-03e733d545b2",
-                        "step_name": "Configuration"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "165",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "3ecbf0dd-0d18-438a-8675-e57ddecad6f2"
+            "uuid": "f815b438-2e48-40c2-83c1-003b32f19760"
         },
         {
             "@type": "WorkflowStep",
@@ -366,7 +413,7 @@
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
-            "uuid": "d3f73ed3-d9c9-40a1-8262-d41d2f0d82ba"
+            "uuid": "915e6a13-58cc-435f-9b7e-ed6250393195"
         },
         {
             "@type": "WorkflowStep",
@@ -396,131 +443,145 @@
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
-            "uuid": "eb147845-3329-4cd1-b4d3-0d58e7604a04"
+            "uuid": "18f57e7b-c825-430a-9b86-fb1c8274b257"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Removing NULL Indicators",
+            "description": "Removing null indicators extracted from email",
+            "arguments": {
+                "unified_iocs": "{{ vars.unified_iocs | json_query('[?value != null]') }}"
+            },
+            "status": null,
+            "top": "1245",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "0311b9ca-831e-45df-ae02-e522633881cf"
         }
     ],
     "routes": [
         {
             "@type": "WorkflowRoute",
             "name": "Update Indicator List -> Get Indicators",
-            "targetStep": "\/api\/3\/workflow_steps\/085701c3-8411-41da-9bc4-86d7ef5660ec",
-            "sourceStep": "\/api\/3\/workflow_steps\/7d4b5714-825d-4abd-a258-18db0cfd3475",
+            "targetStep": "\/api\/3\/workflow_steps\/e7bbfc81-c4c6-4768-a875-e24d81d30de5",
+            "sourceStep": "\/api\/3\/workflow_steps\/b31ff3b1-db1b-4b2d-b170-ebe51e2a63c7",
             "label": null,
             "isExecuted": false,
-            "uuid": "45796dd1-f9fb-4a70-a1d4-3990f2644e13"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Check Reputation Status -> Update Alert State",
-            "targetStep": "\/api\/3\/workflow_steps\/ba6e4c12-47f0-40f3-9ff4-3c16acde7abd",
-            "sourceStep": "\/api\/3\/workflow_steps\/6387638d-9134-4ecb-a492-fe721b866e7a",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "2b8c9353-feba-4b82-b58a-169a2e5ba3c5"
+            "uuid": "1b5471e3-589c-4300-ae5d-f43408a41c30"
         },
         {
             "@type": "WorkflowRoute",
             "name": "Extract Indicators from header -> Extract Indicators from body",
-            "targetStep": "\/api\/3\/workflow_steps\/46eae51d-e1e1-420f-a8f9-5023687232af",
-            "sourceStep": "\/api\/3\/workflow_steps\/1f26db7b-ace2-4ded-bcd7-43fd4e401d19",
+            "targetStep": "\/api\/3\/workflow_steps\/6ea0365a-3a12-495c-82d9-17c787bda75f",
+            "sourceStep": "\/api\/3\/workflow_steps\/9394cafa-441a-4131-b328-bbd2e3339c12",
             "label": null,
             "isExecuted": false,
-            "uuid": "2b0d0c6f-3877-42d2-af09-28c02ad6e256"
+            "uuid": "2c439392-cf08-4dc5-99ce-435b6217072f"
         },
         {
             "@type": "WorkflowRoute",
             "name": "Get Indicators -> Extract Indicators from header",
-            "targetStep": "\/api\/3\/workflow_steps\/1f26db7b-ace2-4ded-bcd7-43fd4e401d19",
-            "sourceStep": "\/api\/3\/workflow_steps\/085701c3-8411-41da-9bc4-86d7ef5660ec",
+            "targetStep": "\/api\/3\/workflow_steps\/9394cafa-441a-4131-b328-bbd2e3339c12",
+            "sourceStep": "\/api\/3\/workflow_steps\/e7bbfc81-c4c6-4768-a875-e24d81d30de5",
             "label": null,
             "isExecuted": false,
-            "uuid": "91000150-9aa1-4262-8f88-6eb088f48b4e"
+            "uuid": "98e591b8-0886-42f2-92c9-afe5d08507ff"
         },
         {
             "@type": "WorkflowRoute",
             "name": "Configuration -> Update Indicator List",
-            "targetStep": "\/api\/3\/workflow_steps\/7d4b5714-825d-4abd-a258-18db0cfd3475",
-            "sourceStep": "\/api\/3\/workflow_steps\/2fcbe2aa-1531-4947-8de8-03e733d545b2",
+            "targetStep": "\/api\/3\/workflow_steps\/b31ff3b1-db1b-4b2d-b170-ebe51e2a63c7",
+            "sourceStep": "\/api\/3\/workflow_steps\/21ffcc50-7679-4df9-bacb-ad7480c465cd",
             "label": null,
             "isExecuted": false,
-            "uuid": "d15beded-415c-4dba-94f7-a5aaf66c0ba3"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Create Indicator -> Wait for Enrichment",
-            "targetStep": "\/api\/3\/workflow_steps\/6387638d-9134-4ecb-a492-fe721b866e7a",
-            "sourceStep": "\/api\/3\/workflow_steps\/c9057eb9-06a7-4b9c-a2d6-4f7f16ae54a0",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "9ef9abf7-9b2e-45f3-a84a-19d248741b1d"
+            "uuid": "546cce30-6434-43fd-af75-c8350c25ae4e"
         },
         {
             "@type": "WorkflowRoute",
             "name": "Unified Email IOCs -> Removing NULL Indicators",
-            "targetStep": "\/api\/3\/workflow_steps\/f0e42b54-be9f-4333-b881-20b73aade2f7",
-            "sourceStep": "\/api\/3\/workflow_steps\/971f518b-11b9-432c-ab86-2b9d67c63f20",
+            "targetStep": "\/api\/3\/workflow_steps\/0311b9ca-831e-45df-ae02-e522633881cf",
+            "sourceStep": "\/api\/3\/workflow_steps\/79976d9e-2f2b-43c1-87a1-76db28946e0e",
             "label": null,
             "isExecuted": false,
-            "uuid": "f5b0a166-2c71-4a3d-9a4d-654ec617b8f0"
+            "uuid": "02b5aefa-5a48-4f99-9c98-b34d19c1f759"
         },
         {
             "@type": "WorkflowRoute",
             "name": "Removing NULL Indicators -> Create Indicator",
-            "targetStep": "\/api\/3\/workflow_steps\/c9057eb9-06a7-4b9c-a2d6-4f7f16ae54a0",
-            "sourceStep": "\/api\/3\/workflow_steps\/f0e42b54-be9f-4333-b881-20b73aade2f7",
+            "targetStep": "\/api\/3\/workflow_steps\/f815b438-2e48-40c2-83c1-003b32f19760",
+            "sourceStep": "\/api\/3\/workflow_steps\/0311b9ca-831e-45df-ae02-e522633881cf",
             "label": null,
             "isExecuted": false,
-            "uuid": "8726ec8f-0495-4d87-aea0-2972500117c7"
+            "uuid": "4a587531-0171-40e9-a498-4fca43701002"
         },
         {
             "@type": "WorkflowRoute",
             "name": "Start -> Is the record for a dedicated tenant",
-            "targetStep": "\/api\/3\/workflow_steps\/3ecbf0dd-0d18-438a-8675-e57ddecad6f2",
-            "sourceStep": "\/api\/3\/workflow_steps\/0b115b6f-1dd8-49e3-ac26-24eb9ecb242b",
+            "targetStep": "\/api\/3\/workflow_steps\/c639685a-e65e-4be4-8fcf-e57613edb51b",
+            "sourceStep": "\/api\/3\/workflow_steps\/c5791d4a-fa1c-41d2-8175-b459c32620e9",
             "label": null,
             "isExecuted": false,
-            "uuid": "326528b9-5a7f-4870-ba51-d7e526c3a02e"
+            "uuid": "bf45ba17-fd3d-45eb-8fa9-565b725d7a09"
         },
         {
             "@type": "WorkflowRoute",
             "name": "Extract Indicators from body -> Extract Indicators from description",
-            "targetStep": "\/api\/3\/workflow_steps\/eb147845-3329-4cd1-b4d3-0d58e7604a04",
-            "sourceStep": "\/api\/3\/workflow_steps\/46eae51d-e1e1-420f-a8f9-5023687232af",
+            "targetStep": "\/api\/3\/workflow_steps\/18f57e7b-c825-430a-9b86-fb1c8274b257",
+            "sourceStep": "\/api\/3\/workflow_steps\/6ea0365a-3a12-495c-82d9-17c787bda75f",
             "label": null,
             "isExecuted": false,
-            "uuid": "8cf2970e-d756-4caf-8d92-aab89a766f14"
+            "uuid": "7ca27a6c-1092-466d-ade0-2f173827d0e6"
         },
         {
             "@type": "WorkflowRoute",
             "name": "Extract Indicators from description -> Unified Email IOCs",
-            "targetStep": "\/api\/3\/workflow_steps\/971f518b-11b9-432c-ab86-2b9d67c63f20",
-            "sourceStep": "\/api\/3\/workflow_steps\/eb147845-3329-4cd1-b4d3-0d58e7604a04",
+            "targetStep": "\/api\/3\/workflow_steps\/79976d9e-2f2b-43c1-87a1-76db28946e0e",
+            "sourceStep": "\/api\/3\/workflow_steps\/18f57e7b-c825-430a-9b86-fb1c8274b257",
             "label": null,
             "isExecuted": false,
-            "uuid": "1fc57de4-bef1-4809-8474-48a408be6501"
+            "uuid": "0b371874-a32d-4043-903b-cbff4d35b11b"
         },
         {
             "@type": "WorkflowRoute",
             "name": "Is the record for a dedicated tenant -> Exit",
-            "targetStep": "\/api\/3\/workflow_steps\/d3f73ed3-d9c9-40a1-8262-d41d2f0d82ba",
-            "sourceStep": "\/api\/3\/workflow_steps\/3ecbf0dd-0d18-438a-8675-e57ddecad6f2",
+            "targetStep": "\/api\/3\/workflow_steps\/915e6a13-58cc-435f-9b7e-ed6250393195",
+            "sourceStep": "\/api\/3\/workflow_steps\/c639685a-e65e-4be4-8fcf-e57613edb51b",
             "label": "Yes, Extract at Tenant Node",
             "isExecuted": false,
-            "uuid": "26b78dab-5c1d-4eae-8dfa-df53b0dae554"
+            "uuid": "eda46593-c13f-4468-82f2-8bfa966a53d9"
         },
         {
             "@type": "WorkflowRoute",
             "name": "Is the record for a dedicated tenant -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/2fcbe2aa-1531-4947-8de8-03e733d545b2",
-            "sourceStep": "\/api\/3\/workflow_steps\/3ecbf0dd-0d18-438a-8675-e57ddecad6f2",
+            "targetStep": "\/api\/3\/workflow_steps\/21ffcc50-7679-4df9-bacb-ad7480c465cd",
+            "sourceStep": "\/api\/3\/workflow_steps\/c639685a-e65e-4be4-8fcf-e57613edb51b",
             "label": "No, Extract Here",
             "isExecuted": false,
-            "uuid": "3620c7ae-c72c-4a17-9832-1ff743c38dbc"
+            "uuid": "298d26b7-1dc1-4ae1-b224-570f4e8c70c9"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Create Indicator -> Wait",
+            "targetStep": "\/api\/3\/workflow_steps\/925de451-5069-41a6-9a5b-ec1a9b071d71",
+            "sourceStep": "\/api\/3\/workflow_steps\/f815b438-2e48-40c2-83c1-003b32f19760",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "74f0c3fc-f08a-454d-9acb-107c94a8d57b"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Wait -> Update Alert State",
+            "targetStep": "\/api\/3\/workflow_steps\/1c47615b-90b3-439d-9d45-eb29b14064ed",
+            "sourceStep": "\/api\/3\/workflow_steps\/925de451-5069-41a6-9a5b-ec1a9b071d71",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "fd31c5f8-f3e9-427a-baa2-479f730eb4df"
         }
     ],
     "groups": [],
     "priority": null,
-    "uuid": "eb230ee2-e402-4327-8dba-1982c84ea1c1",
+    "uuid": "bff221c6-1a9b-4486-8180-6841e7a59f34",
     "owners": [],
     "isPrivate": false,
     "deletedAt": null,


### PR DESCRIPTION
Refer to the bug https://mantis.fortinet.com/bug_view_page.php?bug_id=0832907 (point no 4)

 UT: Modified "Extract Indicators" playbook
- Added a New wait step
> Wait Step iterate on Create Indicators Step
> Wait for the enrichment of the created indicators / Modified Indicators
> following OR conditions are used to wait for indicator enrichments
      > Reputation is Changed and Reputation is not equal to TBD (for new indicators)
      > Enrichment Status is Completed (For existing indicators)
- Modified "Uniqueness conflict settings" to "update some fields of the existing record" for Alert and Last Seen fields 