### PR TITLE
Updated Default Connector Installation List

### DIFF
--- a/connectors/data.json
+++ b/connectors/data.json
@@ -1,54 +1,22 @@
 [
     {
-        "name": "activedirectory",
-        "label": "Active Directory",
-        "category": "Directory Service",
-        "description": "Active Directory (AD) is a directory service that Microsoft developed for Windows domain networks. You can directly query AD to retrieve information about users, groups, and computers, in an organization, by using the Lightweight Directory Access Protocol (LDAP) to directly query the AD.",
-        "publisher": null,
-        "operation_roles": {
-            "add_object": [],
-            "get_all_object_details": [],
-            "get_specific_object_details": [],
-            "update_object": [],
-            "delete_object": [],
-            "add_group_members": [],
-            "remove_group_members": [],
-            "advanced_search": [],
-            "global_search": [],
-            "enable_user_account": [],
-            "disable_user_account": [],
-            "enable_computer": [],
-            "disable_computer": [],
-            "reset_password": []
-        },
-        "configurations": [],
-        "dataImports": [],
-        "install_mode": "rpm"
-    },
-    {
         "name": "alienvault-otx",
         "label": "AlienVault-OTX",
         "category": "Threat Intelligence",
         "description": "AlienVault-OTX is an open source of Indicators of Compromise (IOCs) supported by the community.This connector provides actions Get IP Reputation, Create Pulse, Get Domain Reputation, etc",
         "publisher": null,
-        "operation_roles": {
-            "create_pulse": [],
-            "get_ip_reputation": [],
-            "get_domain_reputation": [],
-            "get_url_reputation": [],
-            "get_file_reputation": [],
-            "get_hostname_reputation": [],
-            "get_all_indicators": [],
-            "get_pulse_indicators": [],
-            "get_pulse_details": [],
-            "get_shared_indicator_pulses": [],
-            "get_subscribed_pulses": [],
-            "run_query": [],
-            "search_pulses": [],
-            "subscribe_pulse": [],
-            "unsubscribe_pulse": [],
-            "user_action": []
-        },
+        "operation_roles": [],
+        "configurations": [],
+        "dataImports": [],
+        "install_mode": "rpm"
+    },
+    {
+        "name": "apivoid",
+        "label": "APIVoid",
+        "category": "Threat Intelligence",
+        "description": "Apivoid connector provides several threat intelligence services ranging from IP\/URL\/Domain reputation to domain age and website screenshots",
+        "publisher": null,
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -59,42 +27,7 @@
         "category": "Endpoint Protection",
         "description": "CarbonBlack Response is purpose-built for enterprise SOC and IR teams.This connector facilitates automated operation related to endpoint protection like isolate endpoint, unisolate endpoint, hunt file, terminate process etc. with CarbonBlack Response server.",
         "publisher": null,
-        "operation_roles": {
-            "get_host_details": [],
-            "isolate_sensor": [],
-            "unisolate_sensor": [],
-            "get_process_list": [],
-            "list_connections": [],
-            "terminate_process": [],
-            "get_file_info_md5": [],
-            "hunt_file": [],
-            "get_blacklisted_hash": [],
-            "block_hash": [],
-            "unblock_hash": [],
-            "delete_file": [],
-            "run_query": [],
-            "search_alert": [],
-            "update_alert": [],
-            "bulk_update_alert": [],
-            "get_watchlist": []
-        },
-        "configurations": [],
-        "dataImports": [],
-        "install_mode": "rpm"
-    },
-    {
-        "name": "elasticsearch",
-        "label": "ElasticSearch",
-        "category": "Database",
-        "description": "ElasticSearch is a distributed, RESTful search and analytics engine capable of solving a number of use cases. This connector facilitates automated operations to execute lucene query, get mapping and cluster details.",
-        "publisher": null,
-        "operation_roles": {
-            "get_cluster_details": [],
-            "get_mapping": [],
-            "execute_query": [],
-            "execute_lucene_query": [],
-            "get_saved_search": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -105,23 +38,7 @@
         "category": "Email Server",
         "description": "The Exchange connector provides a robust, platform-independent, and simple interface for communicating with Microsoft Exchange 2007-2016 Server or Office 365 using Exchange Web Services (EWS).",
         "publisher": null,
-        "operation_roles": {
-            "get_email_new": [],
-            "send_email": [],
-            "mark_as_read": [],
-            "run_query": [],
-            "move_email": [],
-            "copy_email": [],
-            "delete_email": [],
-            "create_calendar_event": [],
-            "get_calendar_events": [],
-            "get_contacts": [],
-            "get_email": [],
-            "get_folder_metadata": [],
-            "add_category": [],
-            "get_category": [],
-            "remove_category": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -129,20 +46,10 @@
     {
         "name": "fortinet-forticlient-ems",
         "label": "Fortinet FortiClient EMS",
-        "category": "Endpoint Management Server",
+        "category": "Endpoint Security",
         "description": "FortiClient Enterprise Management Server (FortiClient EMS) is a security management solution that enables scalable and centralized management of multiple endpoints (computers).This connector provides operations related to quarantine\/unquarantine endpoints, get endpoint details, etc",
         "publisher": null,
-        "operation_roles": {
-            "quarantine_endpoints": [],
-            "unquarantine_endpoints": [],
-            "get_endpoints": [],
-            "get_endpoint_details": [],
-            "get_events_for_endpoint": [],
-            "get_host_verification_rules": [],
-            "get_host_verification_tags": [],
-            "get_profile_by_id": [],
-            "get_all_profiles": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -153,32 +60,7 @@
         "category": "Endpoint Protection",
         "description": "FortiEDR protects endpoints pre and post infection, stopping data breaches in real-time and automatically orchestrating incident investigation and response. This connector facilitates the automated operations related to events, forensics and collectors.",
         "publisher": null,
-        "operation_roles": {
-            "get_event_by_id": [],
-            "get_event_list": [],
-            "update_event": [],
-            "get_raw_data_items": [],
-            "count_events": [],
-            "get_event_list_extended": [],
-            "search": [],
-            "get_file": [],
-            "get_event_file": [],
-            "remediate_device": [],
-            "get_collector_list": [],
-            "isolate_collector": [],
-            "unisolate_collector": [],
-            "create_exception": [],
-            "list_exception": [],
-            "update_exception": [],
-            "get_event_exceptions": [],
-            "get_raw_json_event_data": [],
-            "create_ipset": [],
-            "get_ipset_list": [],
-            "update_ipset": [],
-            "delete_ipset": [],
-            "get_agent_group": [],
-            "get_system_summary": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -186,22 +68,21 @@
     {
         "name": "fortigate-firewall",
         "label": "Fortinet FortiGate",
-        "category": "firewall",
+        "category": "Firewall and Network Protection",
         "description": "Fortinet FortiGate enterprise firewall provide high performance, consolidated advanced security and granular visibility for broad protection across the entire digital attack surface.",
         "publisher": null,
-        "operation_roles": {
-            "get_list_of_policies": [],
-            "get_list_of_applications": [],
-            "get_blocked_ip": [],
-            "get_blocked_applications": [],
-            "get_blocked_urls": [],
-            "block_ip": [],
-            "block_applications": [],
-            "block_url": [],
-            "unblock_ip": [],
-            "unblock_applications": [],
-            "unblock_url": []
-        },
+        "operation_roles": [],
+        "configurations": [],
+        "dataImports": [],
+        "install_mode": "rpm"
+    },
+    {
+        "name": "fortinet-fortiguard-threat-intelligence",
+        "label": "Fortinet FortiGuard Threat Intelligence",
+        "category": "Threat Intelligence",
+        "description": "FortiGuard Threat Intelligence is the global threat intelligence and research organization at Fortinet. This connector facilitates automated operations to check IP, URL, Domain and File Hash Lookup\u2019s and ingestion of daily threat feeds.<br\/><br\/>This connector has a dependency on the <a href=\"\/content-hub\/all-content\/?contentType=solutionpack&amp;tag=ThreatIntelManagement\" target=\"_blank\" rel=\"noopener\">Threat Intel Management Solution Pack<\/a>. Install the Solution Pack before enabling ingestion of Threat Feeds from this source.",
+        "publisher": null,
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -212,24 +93,7 @@
         "category": "Sandbox",
         "description": "FortiSandbox utilizes advanced detection, dynamic antivirus scanning, and threat scanning technology to detect viruses and APTs. FortiSandbox executes suspicious files in the VM host module to determine if the file is High, Medium, or Low Risk based on the behaviour observed in the VM sandbox module. Implemented actions like submit file, get scan stats, get file verdict, get job behaviour and get pdf report etc.",
         "publisher": null,
-        "operation_roles": {
-            "submit_file": [],
-            "submit_urlfile": [],
-            "get_system_status": [],
-            "get_scan_stats": [],
-            "get_submission_job_list": [],
-            "get_scan_result_job": [],
-            "get_file_rating": [],
-            "get_url_rating": [],
-            "get_file_verdict": [],
-            "get_job_behaviour": [],
-            "get_avrescan": [],
-            "get_installed_vm": [],
-            "get_pdf_report": [],
-            "download_hashes_url_from_mwpkg": [],
-            "mark_sample_fp_fn": [],
-            "handle_white_black_list": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -237,51 +101,10 @@
     {
         "name": "fortinet-fortisiem",
         "label": "Fortinet FortiSIEM",
-        "category": "SIEM",
+        "category": "Analytics and SIEM",
         "description": "FortiSIEM provides integrations that allow you to query and make changes to the CMDB, query events, and send incident notifications. Provide actions like get incidents, comment incident, cleared incident, get device details, get monitored organizations, report related actions and get all associated events for an incident from FortiSIEM.",
         "publisher": null,
-        "operation_roles": {
-            "get_incidents": [],
-            "get_incident_details": [],
-            "update_incident": [],
-            "get_associated_events": [],
-            "incident_comment": [],
-            "clear_incident": [],
-            "change_incident_severity": [],
-            "change_incident_resolution": [],
-            "search_events": [],
-            "get_event_details": [],
-            "get_devices_details": [],
-            "get_devices_details_in_address": [],
-            "get_device_info": [],
-            "get_monitored_devices": [],
-            "get_monitored_organizations": [],
-            "get_org_name_by_org_id": [],
-            "run_report": [],
-            "get_incident_attributes": [],
-            "get_events_by_query_id": [],
-            "create_watchlist_group": [],
-            "get_watch_lists": [],
-            "get_watch_list_entries_count": [],
-            "get_watch_list_entry": [],
-            "add_watch_list_entries_to_watch_list_groups": [],
-            "update_watch_list_entry": [],
-            "delete_watch_list_entry": [],
-            "delete_watch_list": []
-        },
-        "configurations": [],
-        "dataImports": [],
-        "install_mode": "rpm"
-    },
-    {
-        "name": "fortinet-web-filter-lookup",
-        "label": "Fortinet Web Filter Lookup",
-        "category": "Site Reputation",
-        "description": "Fortinet Web Filter Lookup allows users to check category and classification for any Domain",
-        "publisher": null,
-        "operation_roles": {
-            "url_review": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -289,40 +112,10 @@
     {
         "name": "xforce",
         "label": "IBM XForce",
-        "category": "SIEM",
+        "category": "Threat Intelligence",
         "description": "IBM XForce connector",
         "publisher": null,
-        "operation_roles": {
-            "get_ip_reputation": [],
-            "get_ip_behaviour": [],
-            "get_ip_report": [],
-            "get_url_report": [],
-            "get_url_behaviour": [],
-            "get_relative_malware": [],
-            "get_file_reputation_using_filehash": [],
-            "get_ip_registrant": [],
-            "search_signature": [],
-            "search_signature_by_xpu": [],
-            "search_signature_by_pamid": [],
-            "get_dns_record": [],
-            "get_vulnerability_from_xfid": [],
-            "get_vulnerability_from_stdcode": [],
-            "get_vulnerability": []
-        },
-        "configurations": [],
-        "dataImports": [],
-        "install_mode": "rpm"
-    },
-    {
-        "name": "ipstack",
-        "label": "IPStack",
-        "category": "Information",
-        "description": "IPStack provides geolocation facility for IP Address or Domain.",
-        "publisher": null,
-        "operation_roles": {
-            "ip_locate": [],
-            "domain_locate": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -333,11 +126,29 @@
         "category": "Threat Intelligence",
         "description": "The IPQualityScore (IPQS) Threat Intelligence application provides threat intelligence for IP addresses, email addresses, URLs, and domains. This connector facilitates automated interactions with a IP Quality Score server using FortiSOAR\u2122 playbooks.",
         "publisher": null,
-        "operation_roles": {
-            "get_ip_reputation": [],
-            "get_email_reputation": [],
-            "get_url_reputation": []
-        },
+        "operation_roles": [],
+        "configurations": [],
+        "dataImports": [],
+        "install_mode": "rpm"
+    },
+    {
+        "name": "ipstack",
+        "label": "IPStack",
+        "category": "Threat Intelligence",
+        "description": "IPStack provides geolocation facility for IP Address or Domain.",
+        "publisher": null,
+        "operation_roles": [],
+        "configurations": [],
+        "dataImports": [],
+        "install_mode": "rpm"
+    },
+    {
+        "name": "microsoft-sccm",
+        "label": "Microsoft SCCM",
+        "category": "Windows Endpoint Management",
+        "description": "Microsoft SCCM Connector",
+        "publisher": null,
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -348,9 +159,7 @@
         "category": "Information",
         "description": "MxToolbox offers monitoring solutions and lookup tools. Connector supports automated operations for Lookup, Monitor and Usage",
         "publisher": null,
-        "operation_roles": {
-            "api_call": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -361,9 +170,7 @@
         "category": "investigation",
         "description": "Nmap is a security scanner provide detailed network information",
         "publisher": null,
-        "operation_roles": {
-            "scan_network": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -374,61 +181,7 @@
         "category": "Information",
         "description": "Calculates\u00a0SLA\u00a0due\u00a0date\u00a0based\u00a0on\u00a0locale\u00a0and\u00a0work hours. This connector needs content pack for supporting playbooks and module changes",
         "publisher": null,
-        "operation_roles": {
-            "calculateSLA": []
-        },
-        "configurations": [
-            {
-                "id": 4,
-                "config_id": "906b3c02-7f22-42fc-8aca-5fbbe378ba36",
-                "status": 1,
-                "name": "Demo",
-                "default": true,
-                "config": {
-                    "timezone": "Asia\/Kolkata",
-                    "full_time": true
-                },
-                "remote_status": [],
-                "health_status": [],
-                "connector": 32,
-                "agent": "8a6a8f28d0aaad8c63109d785142fad5",
-                "teams": []
-            }
-        ],
-        "dataImports": [],
-        "install_mode": "rpm",
-        "ingestionPlaybooks": {
-            "collections": [],
-            "exported_tags": [],
-            "globalVariables": []
-        }
-    },
-    {
-        "name": "threatq",
-        "label": "ThreatQ",
-        "category": "TIP",
-        "description": "ThreatQ Connector",
-        "publisher": null,
-        "operation_roles": {
-            "create_event": [],
-            "create_adversary": [],
-            "create_ioc": [],
-            "get_indicator_types": [],
-            "get_indicator_statuses": [],
-            "get_indicator_reputation": [],
-            "search_indicator": [],
-            "get_ip_reputation": [],
-            "get_domain_reputation": [],
-            "get_url_reputation": [],
-            "get_file_reputation": [],
-            "get_list_of_indicators": [],
-            "get_related_ioc": [],
-            "get_event_types": [],
-            "search_event": [],
-            "get_list_of_events": [],
-            "update_indicator_status": [],
-            "link_ioc": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -436,30 +189,10 @@
     {
         "name": "urlscan-io",
         "label": "URLScan.io",
-        "category": "Sandbox",
-        "description": "URLScan.io provides a service that analyzes websites and the resources they request. URLScan.io provides actions like search domain, ip, hash scan URL and retrieve report of scanned url",
+        "category": "Threat Intelligence",
+        "description": "URLScan.io provides a service that analyzes websites and the resources they request. URLScan.io provides actions like search domain, ip, hash scan URL and retrieve report of scanned url.",
         "publisher": null,
-        "operation_roles": {
-            "get_report": [],
-            "custom_search": [],
-            "search_domain": [],
-            "search_hash": [],
-            "search_ip": [],
-            "submit_url": []
-        },
-        "configurations": [],
-        "dataImports": [],
-        "install_mode": "rpm"
-    },
-    {
-        "name": "urlvoid",
-        "label": "URLVoid",
-        "category": "SandBox",
-        "description": "URLVoid Connector",
-        "publisher": null,
-        "operation_roles": {
-            "domain_reputation": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -467,23 +200,10 @@
     {
         "name": "virustotal",
         "label": "VirusTotal",
-        "category": "Sandbox",
+        "category": "Threat Intelligence",
         "description": "VirusTotal provides a service that analyzes suspicious files and URLs and facilitates the quick detection of viruses, worms, trojans, and all kinds of malware. This connector facilitates automated operations such as scanning and analyzing suspicious files and URLs and retrieving reports from VirusTotal for files, IP addresses, and domains.",
         "publisher": null,
-        "operation_roles": {
-            "upload_sample": [],
-            "scan_url": [],
-            "query_ip": [],
-            "query_domain": [],
-            "query_url": [],
-            "file_reputation": [],
-            "analysis_file": [],
-            "custom_endpoint": [],
-            "get_output_schema_ip": [],
-            "get_output_schema_domain": [],
-            "get_output_schema_url": [],
-            "get_output_schema_file": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"
@@ -491,12 +211,10 @@
     {
         "name": "whois-rdap",
         "label": "Whois RDAP",
-        "category": "Enrichment",
-        "description": "Whois RDAP connector retrieving whois information for given IP Address",
+        "category": "Threat Intelligence",
+        "description": "Whois RDAP is a service that enables you to retrieve information about the location of IP addresses, servers, or websites. You can find out the owner of the Internet resource and their contact details. using this connector we can retrieving whois information for given IP Address.",
         "publisher": null,
-        "operation_roles": {
-            "whois_ip": []
-        },
+        "operation_roles": [],
         "configurations": [],
         "dataImports": [],
         "install_mode": "rpm"

--- a/info.json
+++ b/info.json
@@ -499,20 +499,16 @@
         ],
         "connectors": [
             {
-                "name": "Active Directory",
-                "apiName": "activedirectory"
-            },
-            {
                 "name": "AlienVault-OTX",
                 "apiName": "alienvault-otx"
             },
             {
-                "name": "CarbonBlack Response",
-                "apiName": "carbonblack-response"
+                "name": "APIVoid",
+                "apiName": "apivoid"
             },
             {
-                "name": "ElasticSearch",
-                "apiName": "elasticsearch"
+                "name": "CarbonBlack Response",
+                "apiName": "carbonblack-response"
             },
             {
                 "name": "Exchange",
@@ -531,6 +527,10 @@
                 "apiName": "fortigate-firewall"
             },
             {
+                "name": "Fortinet FortiGuard Threat Intelligence",
+                "apiName": "fortinet-fortiguard-threat-intelligence"
+            },
+            {
                 "name": "Fortinet FortiSandbox",
                 "apiName": "fortinet-fortisandbox"
             },
@@ -539,20 +539,20 @@
                 "apiName": "fortinet-fortisiem"
             },
             {
-                "name": "Fortinet Web Filter Lookup",
-                "apiName": "fortinet-web-filter-lookup"
-            },
-            {
                 "name": "IBM XForce",
                 "apiName": "xforce"
+            },
+            {
+                "name": "IP Quality Score",
+                "apiName": "ip-quality-score"
             },
             {
                 "name": "IPStack",
                 "apiName": "ipstack"
             },
             {
-                "name": "IP Quality Score",
-                "apiName": "ip-quality-score"
+                "name": "Microsoft SCCM",
+                "apiName": "microsoft-sccm"
             },
             {
                 "name": "MxToolbox",
@@ -567,16 +567,8 @@
                 "apiName": "slacalculator"
             },
             {
-                "name": "ThreatQ",
-                "apiName": "threatq"
-            },
-            {
                 "name": "URLScan.io",
                 "apiName": "urlscan-io"
-            },
-            {
-                "name": "URLVoid",
-                "apiName": "urlvoid"
             },
             {
                 "name": "VirusTotal",


### PR DESCRIPTION
BugID: 0842515 - Updated Default Connector Installation List
Following connectors are updated in Default Connector Installation List
1. Active Directory - Removed - Added Enrichment Tag
2. ElasticSearch - Removed - No longer used in SFSP
3. MxtoolBox - Removed - Not used in pluggable enrichment
4. URLVoid - Removed - API changed into APIVoid, hence added APIVoid connector
5. ThreatQ - Removed - Not used in pluggable enrichment
5. Fortinet Web Filter Lookup - Removed - Same Enrichment Summary will get through the Fortinet FortiGuard Threat Intel connector, hence added Fortinet FortiGuard Threat Intel connector