### PR TITLE
Bug Fixes

### DIFF
--- a/playbooks/03 - Enrich/Extract Indicators.json
+++ b/playbooks/03 - Enrich/Extract Indicators.json
@@ -198,62 +198,36 @@
                     "trigger_condition": {
                         "sort": [],
                         "limit": 30,
-                        "logic": "OR",
+                        "logic": "AND",
                         "filters": [
                             {
-                                "logic": "AND",
-                                "filters": [
-                                    {
-                                        "type": "primitive",
-                                        "field": "id",
-                                        "value": "{{vars.item.id}}",
-                                        "operator": "eq",
-                                        "_operator": "eq"
-                                    },
-                                    {
-                                        "type": "object",
-                                        "field": "reputation",
-                                        "value": "",
-                                        "_value": {
-                                            "@id": "",
-                                            "display": "",
-                                            "itemValue": ""
-                                        },
-                                        "operator": "changed"
-                                    },
-                                    {
-                                        "type": "object",
-                                        "field": "reputation",
-                                        "value": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
-                                        "_value": {
-                                            "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
-                                            "itemValue": "TBD"
-                                        },
-                                        "operator": "neq"
-                                    }
-                                ]
+                                "type": "primitive",
+                                "field": "id",
+                                "value": "{{vars.item.id}}",
+                                "operator": "eq",
+                                "_operator": "eq"
                             },
                             {
-                                "logic": "AND",
-                                "filters": [
-                                    {
-                                        "type": "primitive",
-                                        "field": "id",
-                                        "value": "{{vars.item.id}}",
-                                        "operator": "eq",
-                                        "_operator": "eq"
-                                    },
-                                    {
-                                        "type": "object",
-                                        "field": "enrichmentStatus",
-                                        "value": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0",
-                                        "_value": {
-                                            "@id": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0",
-                                            "itemValue": "Completed"
-                                        },
-                                        "operator": "eq"
-                                    }
-                                ]
+                                "type": "object",
+                                "field": "reputation",
+                                "value": "",
+                                "_value": {
+                                    "@id": "",
+                                    "display": "",
+                                    "itemValue": ""
+                                },
+                                "operator": "changed"
+                            },
+                            {
+                                "type": "object",
+                                "field": "reputation",
+                                "value": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                "_value": {
+                                    "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                    "display": "TBD",
+                                    "itemValue": "TBD"
+                                },
+                                "operator": "neq"
                             }
                         ]
                     }
@@ -274,7 +248,7 @@
                 },
                 "for_each": {
                     "item": "{{vars.steps.Create_Indicator}}",
-                    "condition": ""
+                    "condition": "{{vars.item.enrichmentStatus.itemValue != \"Completed\"}}"
                 },
                 "step_variables": []
             },

--- a/playbooks/03 - Enrich/Indicator (Type Host) - Get Reputation.json
+++ b/playbooks/03 - Enrich/Indicator (Type Host) - Get Reputation.json
@@ -1,0 +1,515 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Indicator (Type Host) - Get Reputation",
+    "aliasName": null,
+    "tag": "#Subroutine",
+    "description": "Retrieves the reputation of indicators of type \u2018Host\u2019 using configured threat intelligence tools.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [
+        "indicator_value"
+    ],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/deaa4d19-7444-4f3a-a80e-9577436f25ef",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/1ce62d77-985b-4257-bdbe-ab7f77ddf293",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Asset IRI",
+            "description": null,
+            "arguments": {
+                "asset_iri": "{{vars.steps.Find_Asset[0]['@id']}}",
+                "reputation_iri": "{{(\"IndicatorReputation\" | picklist(\"No Reputation Available\"))[\"@id\"]}}"
+            },
+            "status": null,
+            "top": "30",
+            "left": "2725",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "158401ab-201f-4003-944e-fde286e9e722"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Dedicated Tenant Record",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes, Enrich at Tenant Node",
+                        "step_iri": "\/api\/3\/workflow_steps\/b5045c7c-7161-4af0-8760-65affb3d61a2",
+                        "condition": "{{ 'tenant' in vars.input.records[0] and vars.input.records[0].tenant.isDedicated and vars.input.records[0].tenant.role != 'self' }}",
+                        "step_name": "Exit"
+                    },
+                    {
+                        "option": "No, Enrich Here",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/5c8d1eaf-792b-448c-ab45-ab95ea75d8ec",
+                        "step_name": "Is Referenced Playbook"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "110",
+            "left": "450",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "f47695ba-951d-4452-ae34-da9fa658b79e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Referenced Playbook",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/bd3f2ae5-8017-485a-b92d-8823adfa3b2f",
+                        "condition": "{{ vars.input.params['indicator_value'] | length > 0 }}",
+                        "step_name": "Configuration"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/f1416f0d-c9ee-4850-b599-ee875ee1e178",
+                        "step_name": "Update Enrichment Status to In Process"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "190",
+            "left": "775",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "5c8d1eaf-792b-448c-ab45-ab95ea75d8ec"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": "Indicator reputation is set as 'TBD' by 'Create and Link Indicator' utility playbook. We can ignore those indicators when triggering this PB",
+            "arguments": {
+                "resource": "indicators",
+                "resources": [
+                    "indicators"
+                ],
+                "step_variables": {
+                    "input": {
+                        "params": {
+                            "indicator_value": "{{ vars.indicator_value }}"
+                        },
+                        "records": [
+                            "{{vars.input.records[0]}}"
+                        ]
+                    }
+                },
+                "fieldbasedtrigger": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "object",
+                            "field": "typeofindicator",
+                            "value": "\/api\/3\/picklists\/3272abd8-a1ae-4663-8c47-6d1195e684d9",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/3272abd8-a1ae-4663-8c47-6d1195e684d9",
+                                "itemValue": "Host"
+                            },
+                            "operator": "eq"
+                        },
+                        {
+                            "type": "object",
+                            "field": "indicatorStatus",
+                            "value": "\/api\/3\/picklists\/4218cb58-4de5-4eff-ad08-185d36ef9bab",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/4218cb58-4de5-4eff-ad08-185d36ef9bab",
+                                "itemValue": "Whitelisted"
+                            },
+                            "operator": "neq"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "type": "object",
+                                    "field": "reputation",
+                                    "value": "true",
+                                    "_value": {
+                                        "@id": "true",
+                                        "display": "",
+                                        "itemValue": ""
+                                    },
+                                    "operator": "isnull"
+                                },
+                                {
+                                    "type": "object",
+                                    "field": "reputation",
+                                    "value": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                    "_value": {
+                                        "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                        "display": "TBD",
+                                        "itemValue": "TBD"
+                                    },
+                                    "operator": "eq"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "status": null,
+            "top": "110",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/ea155646-3821-4542-9702-b246da430a8d",
+            "group": null,
+            "uuid": "1ce62d77-985b-4257-bdbe-ab7f77ddf293"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Asset Found",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/f8b65214-7136-4ee0-b026-08cc2a62fd39",
+                        "condition": "{{ vars.steps.Find_Asset | length > 0 }}"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/29822bea-30e8-4b8a-bebc-197f594dbb58"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "190",
+            "left": "2075",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "3f81e473-1453-476a-9ee7-fd96952c57b6"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Exit",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.2.1",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "30",
+            "left": "775",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "b5045c7c-7161-4af0-8760-65affb3d61a2"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Record",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "__link": {
+                        "assets": "{{vars.steps.Find_Asset[0]['@id']}}"
+                    },
+                    "reputation": "{{(\"IndicatorReputation\" | picklist(\"No Reputation Available\"))[\"@id\"]}}",
+                    "enrichmentStatus": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/indicators",
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "190",
+            "left": "2725",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "dbe94fe3-624a-4c70-adb9-0e4594521d7f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "indicator_value": "{{vars.input.params['indicator_value'] | ternary(vars.input.params['indicator_value'],vars.input.records[0].value) }}"
+            },
+            "status": null,
+            "top": "190",
+            "left": "1425",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "bd3f2ae5-8017-485a-b92d-8823adfa3b2f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Asset",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "hostname",
+                            "value": "{{vars.indicator_value}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ]
+                },
+                "module": "assets?$limit=1",
+                "checkboxFields": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "190",
+            "left": "1750",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "4d79a2ab-ae3b-4653-bf42-9bb86a91f25e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Enrichment Status to Completed",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "enrichmentStatus": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/indicators",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "350",
+            "left": "2725",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "14a1c36c-2cde-4d24-998b-cba597c488cd"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Referenced",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Referenced",
+                        "step_iri": "\/api\/3\/workflow_steps\/158401ab-201f-4003-944e-fde286e9e722",
+                        "condition": "{{ vars.input.params['indicator_value'] | length > 0 }}"
+                    },
+                    {
+                        "option": "Upon Create",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/dbe94fe3-624a-4c70-adb9-0e4594521d7f"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "110",
+            "left": "2400",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "f8b65214-7136-4ee0-b026-08cc2a62fd39"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Enrichment Status to In Process",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "enrichmentStatus": "\/api\/3\/picklists\/8a4609d2-8a3d-4bda-9888-5f00bfea43cb"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/indicators",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "145",
+            "left": "1100",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "f1416f0d-c9ee-4850-b599-ee875ee1e178"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set to No Reputation Available",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "reputation": "{{(\"IndicatorReputation\" | picklist(\"No Reputation Available\"))[\"@id\"]}}"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "collectionType": "\/api\/3\/indicators",
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "350",
+            "left": "2400",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "29822bea-30e8-4b8a-bebc-197f594dbb58"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Does Assets Exists",
+            "targetStep": "\/api\/3\/workflow_steps\/4d79a2ab-ae3b-4653-bf42-9bb86a91f25e",
+            "sourceStep": "\/api\/3\/workflow_steps\/bd3f2ae5-8017-485a-b92d-8823adfa3b2f",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "4226fb06-cd89-49b8-a768-41ea2a789b47"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Dedicated Tenant Record -> Is Referenced Playbook",
+            "targetStep": "\/api\/3\/workflow_steps\/5c8d1eaf-792b-448c-ab45-ab95ea75d8ec",
+            "sourceStep": "\/api\/3\/workflow_steps\/f47695ba-951d-4452-ae34-da9fa658b79e",
+            "label": "No, Enrich Here",
+            "isExecuted": false,
+            "uuid": "db9e29c0-7078-45bf-99b3-48f282b40b0c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Referenced Playbook -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/bd3f2ae5-8017-485a-b92d-8823adfa3b2f",
+            "sourceStep": "\/api\/3\/workflow_steps\/5c8d1eaf-792b-448c-ab45-ab95ea75d8ec",
+            "label": "Yes",
+            "isExecuted": false,
+            "uuid": "ee133d09-f448-407f-aee7-f9a191db7e16"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Upon Create -> Asset IRI",
+            "targetStep": "\/api\/3\/workflow_steps\/158401ab-201f-4003-944e-fde286e9e722",
+            "sourceStep": "\/api\/3\/workflow_steps\/f8b65214-7136-4ee0-b026-08cc2a62fd39",
+            "label": "Referenced",
+            "isExecuted": false,
+            "uuid": "891ed2f2-1d0a-46eb-98d0-6535aff85b89"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Enrichment Status to In Process -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/bd3f2ae5-8017-485a-b92d-8823adfa3b2f",
+            "sourceStep": "\/api\/3\/workflow_steps\/f1416f0d-c9ee-4850-b599-ee875ee1e178",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "883e9ef8-4642-4752-8f98-9ce2b0bc5be8"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "If Yes -> Copy  of Update Record",
+            "targetStep": "\/api\/3\/workflow_steps\/29822bea-30e8-4b8a-bebc-197f594dbb58",
+            "sourceStep": "\/api\/3\/workflow_steps\/3f81e473-1453-476a-9ee7-fd96952c57b6",
+            "label": "No",
+            "isExecuted": false,
+            "uuid": "f7c7e9f6-15df-4f95-b5c7-59f826e8467e"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Does Assets Exists -> If Yes",
+            "targetStep": "\/api\/3\/workflow_steps\/3f81e473-1453-476a-9ee7-fd96952c57b6",
+            "sourceStep": "\/api\/3\/workflow_steps\/4d79a2ab-ae3b-4653-bf42-9bb86a91f25e",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "c7d9d965-8ab9-4cde-b478-06e1e637e4cc"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Has Dedicated Tenant Record",
+            "targetStep": "\/api\/3\/workflow_steps\/f47695ba-951d-4452-ae34-da9fa658b79e",
+            "sourceStep": "\/api\/3\/workflow_steps\/1ce62d77-985b-4257-bdbe-ab7f77ddf293",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "36977ab6-1804-4376-929b-d569ef603667"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "If Yes -> Is Upon Create",
+            "targetStep": "\/api\/3\/workflow_steps\/f8b65214-7136-4ee0-b026-08cc2a62fd39",
+            "sourceStep": "\/api\/3\/workflow_steps\/3f81e473-1453-476a-9ee7-fd96952c57b6",
+            "label": "Yes",
+            "isExecuted": false,
+            "uuid": "d803c043-a1fb-4a72-806e-a8315c8f28ed"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Referenced Playbook -> Update Enrichment Status to In Process",
+            "targetStep": "\/api\/3\/workflow_steps\/f1416f0d-c9ee-4850-b599-ee875ee1e178",
+            "sourceStep": "\/api\/3\/workflow_steps\/5c8d1eaf-792b-448c-ab45-ab95ea75d8ec",
+            "label": "No",
+            "isExecuted": false,
+            "uuid": "da62dcb1-39ad-40c0-842e-8a13c0570c33"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Has Dedicated Tenant Record -> Exit",
+            "targetStep": "\/api\/3\/workflow_steps\/b5045c7c-7161-4af0-8760-65affb3d61a2",
+            "sourceStep": "\/api\/3\/workflow_steps\/f47695ba-951d-4452-ae34-da9fa658b79e",
+            "label": "Yes, Enrich at Tenant Node",
+            "isExecuted": false,
+            "uuid": "23557eb1-2735-4d11-9b48-f5ae0c2494b9"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Upon Create -> Update Record",
+            "targetStep": "\/api\/3\/workflow_steps\/dbe94fe3-624a-4c70-adb9-0e4594521d7f",
+            "sourceStep": "\/api\/3\/workflow_steps\/f8b65214-7136-4ee0-b026-08cc2a62fd39",
+            "label": "Upon Create",
+            "isExecuted": false,
+            "uuid": "0a3e1412-c2a7-4b4a-8c5f-619ebb766e89"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Set to No Reputation Available -> Update Enrichment Status to Completed",
+            "targetStep": "\/api\/3\/workflow_steps\/14a1c36c-2cde-4d24-998b-cba597c488cd",
+            "sourceStep": "\/api\/3\/workflow_steps\/29822bea-30e8-4b8a-bebc-197f594dbb58",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "34c68c0d-3f95-441b-bf1d-b6d6329dcd54"
+        }
+    ],
+    "groups": [],
+    "priority": null,
+    "uuid": "4a6f45ea-a029-4cd6-88cf-3798ed282338",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "Subroutine"
+    ]
+}

--- a/playbooks/03 - Enrich/Indicator (Type Port) - Get Reputation.json
+++ b/playbooks/03 - Enrich/Indicator (Type Port) - Get Reputation.json
@@ -1,0 +1,370 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Indicator (Type Port) - Get Reputation",
+    "aliasName": null,
+    "tag": "#Subroutine",
+    "description": "Retrieves the reputation of indicators of type \u2018Port\u2019 using configured threat intelligence tools.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [
+        "indicator_value"
+    ],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/deaa4d19-7444-4f3a-a80e-9577436f25ef",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/23b99aca-db8e-4cd0-a918-b92e25f5016d",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "indicator_value": "{{vars.input.params['indicator_value'] | ternary(vars.input.params['indicator_value'],vars.input.records[0].value) }}"
+            },
+            "status": null,
+            "top": "190",
+            "left": "1425",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "04eec041-003a-4d2c-9f36-874289e0c12a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": "Indicator reputation is set as 'TBD' by 'Create and Link Indicator' utility playbook. We can ignore those indicators when triggering this PB",
+            "arguments": {
+                "resource": "indicators",
+                "resources": [
+                    "indicators"
+                ],
+                "step_variables": {
+                    "input": {
+                        "params": {
+                            "indicator_value": "{{ vars.indicator_value }}"
+                        },
+                        "records": [
+                            "{{vars.input.records[0]}}"
+                        ]
+                    }
+                },
+                "fieldbasedtrigger": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "object",
+                            "field": "typeofindicator",
+                            "value": "\/api\/3\/picklists\/1c4def41-b578-49a3-9063-8aa46f757c08",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/1c4def41-b578-49a3-9063-8aa46f757c08",
+                                "itemValue": "Port"
+                            },
+                            "operator": "eq"
+                        },
+                        {
+                            "type": "object",
+                            "field": "indicatorStatus",
+                            "value": "\/api\/3\/picklists\/4218cb58-4de5-4eff-ad08-185d36ef9bab",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/4218cb58-4de5-4eff-ad08-185d36ef9bab",
+                                "itemValue": "Whitelisted"
+                            },
+                            "operator": "neq"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "type": "object",
+                                    "field": "reputation",
+                                    "value": "true",
+                                    "_value": {
+                                        "@id": "true",
+                                        "display": "",
+                                        "itemValue": ""
+                                    },
+                                    "operator": "isnull"
+                                },
+                                {
+                                    "type": "object",
+                                    "field": "reputation",
+                                    "value": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                    "_value": {
+                                        "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                        "itemValue": "TBD"
+                                    },
+                                    "operator": "eq"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "status": null,
+            "top": "110",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/ea155646-3821-4542-9702-b246da430a8d",
+            "group": null,
+            "uuid": "23b99aca-db8e-4cd0-a918-b92e25f5016d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Referenced",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Referenced",
+                        "step_iri": "\/api\/3\/workflow_steps\/6c437105-5f0a-440b-b7da-8a52432b70fb",
+                        "condition": "{{ vars.input.params['indicator_value'] | length > 0 }}"
+                    },
+                    {
+                        "option": "Upon Create",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/772c1992-9b60-4a27-9994-2fd86ade96ca"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "190",
+            "left": "1750",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "2beeb97d-954f-4a9c-8762-dfe5a07befa9"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Enrichment Status to In Process",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "enrichmentStatus": "\/api\/3\/picklists\/8a4609d2-8a3d-4bda-9888-5f00bfea43cb"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/indicators",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "145",
+            "left": "1100",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "65b1d579-0987-4496-b6c0-0b9407047c01"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Reputation",
+            "description": null,
+            "arguments": {
+                "reputation_iri": "{{(\"IndicatorReputation\" | picklist(\"No Reputation Available\"))[\"@id\"]}}"
+            },
+            "status": null,
+            "top": "110",
+            "left": "2075",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "6c437105-5f0a-440b-b7da-8a52432b70fb"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Record",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "reputation": "\/api\/3\/picklists\/9a611980-1b5e-4ae9-8062-eb2c0c433cff",
+                    "enrichmentStatus": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/indicators",
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "270",
+            "left": "2075",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "772c1992-9b60-4a27-9994-2fd86ade96ca"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Dedicated Tenant Record",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes, Enrich at Tenant Node",
+                        "step_iri": "\/api\/3\/workflow_steps\/f6df1b6e-d112-4f07-a54b-58bbc24a5bdd",
+                        "condition": "{{ 'tenant' in vars.input.records[0] and vars.input.records[0].tenant.isDedicated and vars.input.records[0].tenant.role != 'self' }}",
+                        "step_name": "Exit"
+                    },
+                    {
+                        "option": "No, Enrich Here",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/fa6f48b1-0026-4d18-9304-b9a0a5257c6a",
+                        "step_name": "Is Referenced Playbook"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "110",
+            "left": "450",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "a0707036-1bb0-4ee5-8208-3c92ac906621"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Exit",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.2.1",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "30",
+            "left": "775",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "f6df1b6e-d112-4f07-a54b-58bbc24a5bdd"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Referenced Playbook",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/04eec041-003a-4d2c-9f36-874289e0c12a",
+                        "condition": "{{ vars.input.params['indicator_value'] | length > 0 }}",
+                        "step_name": "Configuration"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/65b1d579-0987-4496-b6c0-0b9407047c01",
+                        "step_name": "Update Enrichment Status to In Process"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "190",
+            "left": "775",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "fa6f48b1-0026-4d18-9304-b9a0a5257c6a"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Enrichment Status to In Process -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/04eec041-003a-4d2c-9f36-874289e0c12a",
+            "sourceStep": "\/api\/3\/workflow_steps\/65b1d579-0987-4496-b6c0-0b9407047c01",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "eb389f64-871e-4cea-b8f7-b8129a0df535"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Upon Create -> Asset IRI",
+            "targetStep": "\/api\/3\/workflow_steps\/6c437105-5f0a-440b-b7da-8a52432b70fb",
+            "sourceStep": "\/api\/3\/workflow_steps\/2beeb97d-954f-4a9c-8762-dfe5a07befa9",
+            "label": "Referenced",
+            "isExecuted": false,
+            "uuid": "3b2ae490-a9d4-4eae-9de3-1190d83b80d2"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Referenced Playbook -> Update Enrichment Status to In Process",
+            "targetStep": "\/api\/3\/workflow_steps\/65b1d579-0987-4496-b6c0-0b9407047c01",
+            "sourceStep": "\/api\/3\/workflow_steps\/fa6f48b1-0026-4d18-9304-b9a0a5257c6a",
+            "label": "No",
+            "isExecuted": false,
+            "uuid": "301133da-b5d6-4152-9bc5-8f6575ac630d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Referenced Playbook -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/04eec041-003a-4d2c-9f36-874289e0c12a",
+            "sourceStep": "\/api\/3\/workflow_steps\/fa6f48b1-0026-4d18-9304-b9a0a5257c6a",
+            "label": "Yes",
+            "isExecuted": false,
+            "uuid": "363c4e73-c17f-489e-85c9-576fb759a72d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Dedicated Tenant Record -> Is Referenced Playbook",
+            "targetStep": "\/api\/3\/workflow_steps\/fa6f48b1-0026-4d18-9304-b9a0a5257c6a",
+            "sourceStep": "\/api\/3\/workflow_steps\/a0707036-1bb0-4ee5-8208-3c92ac906621",
+            "label": "No, Enrich Here",
+            "isExecuted": false,
+            "uuid": "fe429d3d-a10a-4a41-865a-955f48a8f43a"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Has Dedicated Tenant Record -> Exit",
+            "targetStep": "\/api\/3\/workflow_steps\/f6df1b6e-d112-4f07-a54b-58bbc24a5bdd",
+            "sourceStep": "\/api\/3\/workflow_steps\/a0707036-1bb0-4ee5-8208-3c92ac906621",
+            "label": "Yes, Enrich at Tenant Node",
+            "isExecuted": false,
+            "uuid": "2fe29c72-8e74-490f-aea2-292a3b88193b"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Is Referenced",
+            "targetStep": "\/api\/3\/workflow_steps\/2beeb97d-954f-4a9c-8762-dfe5a07befa9",
+            "sourceStep": "\/api\/3\/workflow_steps\/04eec041-003a-4d2c-9f36-874289e0c12a",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "3514af0b-5848-451c-9cb1-bc99c7724be1"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Has Dedicated Tenant Record",
+            "targetStep": "\/api\/3\/workflow_steps\/a0707036-1bb0-4ee5-8208-3c92ac906621",
+            "sourceStep": "\/api\/3\/workflow_steps\/23b99aca-db8e-4cd0-a918-b92e25f5016d",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "83db03b9-4f43-48f0-adc4-f61f385f3573"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Upon Create -> Update Record",
+            "targetStep": "\/api\/3\/workflow_steps\/772c1992-9b60-4a27-9994-2fd86ade96ca",
+            "sourceStep": "\/api\/3\/workflow_steps\/2beeb97d-954f-4a9c-8762-dfe5a07befa9",
+            "label": "Upon Create",
+            "isExecuted": false,
+            "uuid": "a72bf3b8-638a-48f9-a854-7c151e0a47e3"
+        }
+    ],
+    "groups": [],
+    "priority": null,
+    "uuid": "01629382-b6a7-450d-8179-6b2faa9ad977",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "PostCreate"
+    ]
+}

--- a/playbooks/03 - Enrich/Indicator (Type Process) - Get Reputation.json
+++ b/playbooks/03 - Enrich/Indicator (Type Process) - Get Reputation.json
@@ -1,0 +1,370 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Indicator (Type Process) - Get Reputation",
+    "aliasName": null,
+    "tag": "#Subroutine",
+    "description": "Retrieves the reputation of indicators of type \u2018Process\u2019 using configured threat intelligence tools.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [
+        "indicator_value"
+    ],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/deaa4d19-7444-4f3a-a80e-9577436f25ef",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/7d3e7837-61e2-4161-9b08-e638435f66fb",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Reputation",
+            "description": null,
+            "arguments": {
+                "reputation_iri": "{{(\"IndicatorReputation\" | picklist(\"No Reputation Available\"))[\"@id\"]}}"
+            },
+            "status": null,
+            "top": "270",
+            "left": "2075",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "2e6c0514-6a0a-4431-a68b-93d60c29c161"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Referenced Playbook",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/c7408946-3309-441d-a29c-e04ad8c2763b",
+                        "condition": "{{ vars.input.params['indicator_value'] | length > 0 }}",
+                        "step_name": "Configuration"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/cf75d399-4cb8-4984-a7eb-d8e9645593df",
+                        "step_name": "Update Enrichment Status to In Process"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "190",
+            "left": "775",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "3530f92c-a564-4da1-8691-3e6e5011e167"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Record",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "reputation": "\/api\/3\/picklists\/9a611980-1b5e-4ae9-8062-eb2c0c433cff",
+                    "enrichmentStatus": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/indicators",
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "110",
+            "left": "2075",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "4860e713-1242-45db-b687-2513b12f5d10"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Dedicated Tenant Record",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes, Enrich at Tenant Node",
+                        "step_iri": "\/api\/3\/workflow_steps\/d18264ab-8e67-4e97-a4ce-224e6f4c61e1",
+                        "condition": "{{ 'tenant' in vars.input.records[0] and vars.input.records[0].tenant.isDedicated and vars.input.records[0].tenant.role != 'self' }}",
+                        "step_name": "Exit"
+                    },
+                    {
+                        "option": "No, Enrich Here",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/3530f92c-a564-4da1-8691-3e6e5011e167",
+                        "step_name": "Is Referenced Playbook"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "110",
+            "left": "450",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "48d26085-1c0e-40e1-9a9c-4569ff053988"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": "Indicator reputation is set as 'TBD' by 'Create and Link Indicator' utility playbook. We can ignore those indicators when triggering this PB",
+            "arguments": {
+                "resource": "indicators",
+                "resources": [
+                    "indicators"
+                ],
+                "step_variables": {
+                    "input": {
+                        "params": {
+                            "indicator_value": "{{ vars.indicator_value }}"
+                        },
+                        "records": [
+                            "{{vars.input.records[0]}}"
+                        ]
+                    }
+                },
+                "fieldbasedtrigger": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "object",
+                            "field": "typeofindicator",
+                            "value": "\/api\/3\/picklists\/a6ab7480-a0b1-4917-a6b9-c9b16ddc7e9b",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/a6ab7480-a0b1-4917-a6b9-c9b16ddc7e9b",
+                                "itemValue": "Process"
+                            },
+                            "operator": "eq"
+                        },
+                        {
+                            "type": "object",
+                            "field": "indicatorStatus",
+                            "value": "\/api\/3\/picklists\/4218cb58-4de5-4eff-ad08-185d36ef9bab",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/4218cb58-4de5-4eff-ad08-185d36ef9bab",
+                                "itemValue": "Whitelisted"
+                            },
+                            "operator": "neq"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "type": "object",
+                                    "field": "reputation",
+                                    "value": "true",
+                                    "_value": {
+                                        "@id": "true",
+                                        "display": "",
+                                        "itemValue": ""
+                                    },
+                                    "operator": "isnull"
+                                },
+                                {
+                                    "type": "object",
+                                    "field": "reputation",
+                                    "value": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                    "_value": {
+                                        "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                        "itemValue": "TBD"
+                                    },
+                                    "operator": "eq"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "status": null,
+            "top": "110",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/ea155646-3821-4542-9702-b246da430a8d",
+            "group": null,
+            "uuid": "7d3e7837-61e2-4161-9b08-e638435f66fb"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Referenced",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Referenced",
+                        "step_iri": "\/api\/3\/workflow_steps\/2e6c0514-6a0a-4431-a68b-93d60c29c161",
+                        "condition": "{{ vars.input.params['indicator_value'] | length > 0 }}"
+                    },
+                    {
+                        "option": "Upon Create",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/4860e713-1242-45db-b687-2513b12f5d10"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "190",
+            "left": "1750",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "8c490827-4e25-4808-9871-f1e3543c6bc1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "indicator_value": "{{vars.input.params['indicator_value'] | ternary(vars.input.params['indicator_value'],vars.input.records[0].value) }}"
+            },
+            "status": null,
+            "top": "190",
+            "left": "1425",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "c7408946-3309-441d-a29c-e04ad8c2763b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Enrichment Status to In Process",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "enrichmentStatus": "\/api\/3\/picklists\/8a4609d2-8a3d-4bda-9888-5f00bfea43cb"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/indicators",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "145",
+            "left": "1100",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "cf75d399-4cb8-4984-a7eb-d8e9645593df"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Exit",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.2.1",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "30",
+            "left": "775",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "d18264ab-8e67-4e97-a4ce-224e6f4c61e1"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Enrichment Status to In Process -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/c7408946-3309-441d-a29c-e04ad8c2763b",
+            "sourceStep": "\/api\/3\/workflow_steps\/cf75d399-4cb8-4984-a7eb-d8e9645593df",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "89ee27f2-55ad-4539-baf3-a4565d6fb5c0"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Upon Create -> Update Record",
+            "targetStep": "\/api\/3\/workflow_steps\/4860e713-1242-45db-b687-2513b12f5d10",
+            "sourceStep": "\/api\/3\/workflow_steps\/8c490827-4e25-4808-9871-f1e3543c6bc1",
+            "label": "Upon Create",
+            "isExecuted": false,
+            "uuid": "3f7e0eb6-cdd1-4791-94cd-5c8da7f61b4f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Upon Create -> Asset IRI",
+            "targetStep": "\/api\/3\/workflow_steps\/2e6c0514-6a0a-4431-a68b-93d60c29c161",
+            "sourceStep": "\/api\/3\/workflow_steps\/8c490827-4e25-4808-9871-f1e3543c6bc1",
+            "label": "Referenced",
+            "isExecuted": false,
+            "uuid": "cf41f625-86b0-4f29-bc77-0692f130bac2"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Referenced Playbook -> Update Enrichment Status to In Process",
+            "targetStep": "\/api\/3\/workflow_steps\/cf75d399-4cb8-4984-a7eb-d8e9645593df",
+            "sourceStep": "\/api\/3\/workflow_steps\/3530f92c-a564-4da1-8691-3e6e5011e167",
+            "label": "No",
+            "isExecuted": false,
+            "uuid": "546b53fa-b87f-4ae4-8f9c-f47980ae42dd"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Is Referenced",
+            "targetStep": "\/api\/3\/workflow_steps\/8c490827-4e25-4808-9871-f1e3543c6bc1",
+            "sourceStep": "\/api\/3\/workflow_steps\/c7408946-3309-441d-a29c-e04ad8c2763b",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "4239a705-dc2a-43b6-a6bb-c0206b0d7623"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Has Dedicated Tenant Record",
+            "targetStep": "\/api\/3\/workflow_steps\/48d26085-1c0e-40e1-9a9c-4569ff053988",
+            "sourceStep": "\/api\/3\/workflow_steps\/7d3e7837-61e2-4161-9b08-e638435f66fb",
+            "label": null,
+            "isExecuted": false,
+            "uuid": "04f72a81-f07a-4ada-9734-d23760171c5d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Has Dedicated Tenant Record -> Exit",
+            "targetStep": "\/api\/3\/workflow_steps\/d18264ab-8e67-4e97-a4ce-224e6f4c61e1",
+            "sourceStep": "\/api\/3\/workflow_steps\/48d26085-1c0e-40e1-9a9c-4569ff053988",
+            "label": "Yes, Enrich at Tenant Node",
+            "isExecuted": false,
+            "uuid": "0d9dd1ed-76c9-460b-8bb6-76a0d3708ec1"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Referenced Playbook -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/c7408946-3309-441d-a29c-e04ad8c2763b",
+            "sourceStep": "\/api\/3\/workflow_steps\/3530f92c-a564-4da1-8691-3e6e5011e167",
+            "label": "Yes",
+            "isExecuted": false,
+            "uuid": "8416b023-9bfe-43af-835f-b52d886d2046"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Dedicated Tenant Record -> Is Referenced Playbook",
+            "targetStep": "\/api\/3\/workflow_steps\/3530f92c-a564-4da1-8691-3e6e5011e167",
+            "sourceStep": "\/api\/3\/workflow_steps\/48d26085-1c0e-40e1-9a9c-4569ff053988",
+            "label": "No, Enrich Here",
+            "isExecuted": false,
+            "uuid": "85324429-493b-48ca-af83-c034d510b295"
+        }
+    ],
+    "groups": [],
+    "priority": null,
+    "uuid": "0fd7237e-cb91-4e78-9907-eecbb23ff36a",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "Subroutine"
+    ]
+}


### PR DESCRIPTION
0849828 - Update Extract Indicator Playbook
Unit Test Cases: Removed re-enrichment condition
1. Created demo phishing type alert which extract and enrich indicators
2. Deleted phishing alert
3. Remove some correlated indicators and remaining kept as it is
4. Created same demo phishing type alert and observed that the new created indicators are enriched by checking the condition that enrichment status is not completed 

0849832: Added new playbooks in 03-Enrich Collection
Added following playbooks in 03-Enrich playbook Collection to enrich the indicator type Port, Host and Process
Indicator (Type Host) - Get Reputation
Indicator (Type Port) - Get Reputation
Indicator (Type Process) - Get Reputation
Unit Test Case:
1. Created indicators of type Port, Process and Host
2. Indicator enrichment completed with reputation "No Reputation Available" and Enrichment Status set to Completed 
