### PR TITLE
BugFix 0848269

### DIFF
--- a/playbooks/06 - IRP - Case Management/Alert - [02] Capture Ack SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Alert - [02] Capture Ack SLA (Upon Update).json
@@ -17,6 +17,54 @@
     "steps": [
         {
             "@type": "WorkflowStep",
+            "name": "Get SLA Details",
+            "description": null,
+            "arguments": {
+                "arguments": {
+                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
+                    "inc_severity": "{{vars.input.records[0].severity.itemValue}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "sla_time_list": "{{vars.result.sla_time_list}}"
+                },
+                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
+            },
+            "status": null,
+            "top": "165",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "0442c07a-96d8-4d43-a984-4def4fb61db1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Recalculate Ack SLA",
+            "description": null,
+            "arguments": {
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == \"Awaiting Action\" or vars.input.records[0].ackSlaStatus.itemValue == \"Paused\" ) and vars.input.records[0].status.itemValue != \"Closed\"}}",
+                "config": "4b6b27cf-86a5-4c5d-a7f8-0186dbc623b5",
+                "params": {
+                    "slaTime": "{%if vars.input.records[0].alertRemainingAckSLA %}{{vars.input.records[0].alertRemainingAckSLA}}{%else%}{{vars.sla_time_list.alertAckTime}}{%endif%}",
+                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
+                },
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "084b0d14-e47e-4cc5-9a12-79bbd46d5014"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Start",
             "description": null,
             "arguments": {
@@ -26,6 +74,7 @@
                 ],
                 "step_variables": {
                     "input": {
+                        "params": [],
                         "records": [
                             "{{vars.input.records[0]}}"
                         ]
@@ -46,6 +95,21 @@
                                 "itemValue": ""
                             },
                             "operator": "changed"
+                        },
+                        {
+                            "type": "array",
+                            "field": "ackSlaStatus",
+                            "value": [
+                                "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                                "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34"
+                            ],
+                            "module": "ackSlaStatus",
+                            "display": "",
+                            "operator": "nin",
+                            "template": "multiselectpicklist",
+                            "OPERATOR_KEY": "$",
+                            "previousOperator": "nin",
+                            "previousTemplate": "multiselectpicklist"
                         }
                     ]
                 }
@@ -54,177 +118,8 @@
             "top": "30",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
+            "group": null,
             "uuid": "0968f9df-27b7-4720-acd9-4b48223ffd6f"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Status Check for Ack SLA",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Set Ack Date",
-                        "step_iri": "\/api\/3\/workflow_steps\/8386bc90-78a0-46b2-b33f-655c697b24d2",
-                        "condition": "{{ vars.input.records[0].status.itemValue == vars.steps.Get_SLA_Details.sla_time_list.alertAackTrackedOn }}",
-                        "step_name": "Check Acknowledge SLA Status"
-                    },
-                    {
-                        "option": "Recalculate Ack SLA",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/084b0d14-e47e-4cc5-9a12-79bbd46d5014",
-                        "step_name": "Recalculate Ack SLA"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "435",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "b3e774bc-69e1-4067-a78e-e1d01f59da2a"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Check Acknowledge SLA Status",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Missed",
-                        "step_iri": "\/api\/3\/workflow_steps\/a7e1b006-d4af-4e6d-ad37-76940f2b490f",
-                        "condition": "{{ vars.input.records[0].modifyDate > vars.input.records[0].dueBy }}"
-                    },
-                    {
-                        "option": "Met",
-                        "step_iri": "\/api\/3\/workflow_steps\/c73720f8-10c9-46d7-ba3b-7da00c99117f",
-                        "condition": "{{ vars.input.records[0].modifyDate <  vars.input.records[0].dueBy }}"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "570",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "8386bc90-78a0-46b2-b33f-655c697b24d2"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Acknowledge SLA as Missed",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].ackSlaStatus.itemValue == \"Awaiting Action\" or vars.input.records[0].ackSlaStatus.itemValue == \"Paused\" or vars.input.records[0].ackSlaStatus.itemValue == \"NA\"}}",
-                "resource": {
-                    "ackDate": "{{globalVars.Current_Date}}",
-                    "ackSlaStatus": {
-                        "id": 506,
-                        "@id": "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34",
-                        "icon": null,
-                        "@type": "Picklist",
-                        "color": "#de2020",
-                        "display": "Missed",
-                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
-                        "itemValue": "Missed",
-                        "orderIndex": 1
-                    }
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "tagsOperation": "OverwriteTags",
-                "collectionType": "\/api\/3\/alerts",
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "705",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "a7e1b006-d4af-4e6d-ad37-76940f2b490f"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Acknowledge SLA as Met",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].ackSlaStatus.itemValue == \"Awaiting Action\" or vars.input.records[0].ackSlaStatus.itemValue == \"Paused\" or vars.input.records[0].ackSlaStatus.itemValue == \"NA\"}}",
-                "resource": {
-                    "ackDate": "{{globalVars.Current_Date}}",
-                    "ackSlaStatus": {
-                        "id": 505,
-                        "@id": "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
-                        "icon": null,
-                        "@type": "Picklist",
-                        "color": "#14b341",
-                        "display": "Met",
-                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
-                        "itemValue": "Met",
-                        "orderIndex": 0
-                    }
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "tagsOperation": "OverwriteTags",
-                "collectionType": "\/api\/3\/alerts",
-                "fieldOperation": {
-                    "category": "Append",
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "705",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "c73720f8-10c9-46d7-ba3b-7da00c99117f"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get SLA Details",
-            "description": null,
-            "arguments": {
-                "arguments": {
-                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
-                    "inc_severity": "{{vars.input.records[0].severity.itemValue}}"
-                },
-                "apply_async": false,
-                "step_variables": {
-                    "sla_time_list": "{{vars.result.sla_time_list}}"
-                },
-                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
-            },
-            "status": null,
-            "top": "165",
-            "left": "650",
-            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-            "uuid": "0442c07a-96d8-4d43-a984-4def4fb61db1"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Check Current Status To Pause SLA",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Pause SLA",
-                        "step_iri": "\/api\/3\/workflow_steps\/0cf46ca0-c4d3-4682-9e9a-7b93fe811fdc",
-                        "condition": "{{ vars.input.records[0].status.itemValue == vars.sla_time_list.altPauseSLAOn }}",
-                        "step_name": "Pause Ack SLA"
-                    },
-                    {
-                        "option": "Check Status for Ack SLA",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/b3e774bc-69e1-4067-a78e-e1d01f59da2a",
-                        "step_name": "Status Check for Ack SLA"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "300",
-            "left": "650",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "4b47d563-2b8e-47c0-aee6-8c47bb23db0c"
         },
         {
             "@type": "WorkflowStep",
@@ -262,52 +157,18 @@
             "top": "435",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
             "uuid": "0cf46ca0-c4d3-4682-9e9a-7b93fe811fdc"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Recalculate Ack SLA",
-            "description": null,
-            "arguments": {
-                "name": "SLA Calculator",
-                "config": "4b6b27cf-86a5-4c5d-a7f8-0186dbc623b5",
-                "params": {
-                    "slaTime": "{%if vars.input.records[0].alertRemainingAckSLA %}{{vars.input.records[0].alertRemainingAckSLA}}{%else%}{{vars.sla_time_list.alertAckTime}}{%endif%}",
-                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
-                },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "570",
-            "left": "825",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "084b0d14-e47e-4cc5-9a12-79bbd46d5014"
         },
         {
             "@type": "WorkflowStep",
             "name": "Resume Ack SLA",
             "description": null,
             "arguments": {
-                "when": "{{vars.input.records[0].ackSlaStatus.itemValue == \"Awaiting Action\" or vars.input.records[0].ackSlaStatus.itemValue == \"Paused\"}}",
+                "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == \"Awaiting Action\" or vars.input.records[0].ackSlaStatus.itemValue == \"Paused\" ) and vars.input.records[0].status.itemValue != \"Closed\"}}",
                 "resource": {
                     "dueBy": "{{vars.steps.Recalculate_Ack_SLA.data['sla_due_date_timestamp']}}",
-                    "ackSlaStatus": {
-                        "id": 270,
-                        "@id": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
-                        "icon": null,
-                        "@type": "Picklist",
-                        "color": "#808080",
-                        "display": "Awaiting Action",
-                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
-                        "itemValue": "Awaiting Action",
-                        "orderIndex": 2
-                    },
-                    "ackSLApausedon": "None"
+                    "ackSlaStatus": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818"
                 },
                 "_showJson": false,
                 "operation": "Append",
@@ -323,7 +184,162 @@
             "top": "705",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
             "uuid": "371bbc26-069a-4961-b7f6-1744494510cc"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Current Status To Pause SLA",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Pause SLA",
+                        "step_iri": "\/api\/3\/workflow_steps\/0cf46ca0-c4d3-4682-9e9a-7b93fe811fdc",
+                        "condition": "{{ vars.input.records[0].status.itemValue == vars.sla_time_list.altPauseSLAOn }}",
+                        "step_name": "Pause Ack SLA"
+                    },
+                    {
+                        "option": "Check Status for Ack SLA",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/b3e774bc-69e1-4067-a78e-e1d01f59da2a",
+                        "step_name": "Status Check for Ack SLA"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "300",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "4b47d563-2b8e-47c0-aee6-8c47bb23db0c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Acknowledge SLA Status",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Missed",
+                        "step_iri": "\/api\/3\/workflow_steps\/a7e1b006-d4af-4e6d-ad37-76940f2b490f",
+                        "condition": "{{ vars.input.records[0].modifyDate > vars.input.records[0].dueBy }}"
+                    },
+                    {
+                        "option": "Met",
+                        "step_iri": "\/api\/3\/workflow_steps\/c73720f8-10c9-46d7-ba3b-7da00c99117f",
+                        "condition": "{{ vars.input.records[0].modifyDate <  vars.input.records[0].dueBy }}"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "570",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "8386bc90-78a0-46b2-b33f-655c697b24d2"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Acknowledge SLA as Missed",
+            "description": null,
+            "arguments": {
+                "when": "{{vars.input.records[0].ackSlaStatus.itemValue == \"Awaiting Action\" or vars.input.records[0].ackSlaStatus.itemValue == \"Paused\" or vars.input.records[0].ackSlaStatus.itemValue == \"NA\"}}",
+                "resource": {
+                    "ackDate": "{{globalVars.Current_Date}}",
+                    "ackSlaStatus": {
+                        "id": 506,
+                        "@id": "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34",
+                        "icon": null,
+                        "@type": "Picklist",
+                        "color": "#de2020",
+                        "display": "Missed",
+                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
+                        "itemValue": "Missed",
+                        "orderIndex": 1
+                    }
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "tagsOperation": "OverwriteTags",
+                "collectionType": "\/api\/3\/alerts",
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "a7e1b006-d4af-4e6d-ad37-76940f2b490f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Status Check for Ack SLA",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Set Ack Date",
+                        "step_iri": "\/api\/3\/workflow_steps\/8386bc90-78a0-46b2-b33f-655c697b24d2",
+                        "condition": "{{ vars.input.records[0].status.itemValue == vars.steps.Get_SLA_Details.sla_time_list.alertAackTrackedOn }}",
+                        "step_name": "Check Acknowledge SLA Status"
+                    },
+                    {
+                        "option": "Recalculate Ack SLA",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/084b0d14-e47e-4cc5-9a12-79bbd46d5014",
+                        "step_name": "Recalculate Ack SLA"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "435",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "b3e774bc-69e1-4067-a78e-e1d01f59da2a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Acknowledge SLA as Met",
+            "description": null,
+            "arguments": {
+                "when": "{{vars.input.records[0].ackSlaStatus.itemValue == \"Awaiting Action\" or vars.input.records[0].ackSlaStatus.itemValue == \"Paused\" or vars.input.records[0].ackSlaStatus.itemValue == \"NA\"}}",
+                "resource": {
+                    "ackDate": "{{globalVars.Current_Date}}",
+                    "ackSlaStatus": {
+                        "id": 505,
+                        "@id": "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                        "icon": null,
+                        "@type": "Picklist",
+                        "color": "#14b341",
+                        "display": "Met",
+                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
+                        "itemValue": "Met",
+                        "orderIndex": 0
+                    }
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "tagsOperation": "OverwriteTags",
+                "collectionType": "\/api\/3\/alerts",
+                "fieldOperation": {
+                    "category": "Append",
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "c73720f8-10c9-46d7-ba3b-7da00c99117f"
         }
     ],
     "routes": [
@@ -409,6 +425,7 @@
             "uuid": "8bf2310a-2097-46d5-86a2-5de8ca46fbfa"
         }
     ],
+    "groups": [],
     "priority": null,
     "uuid": "25e66494-49b4-4601-a956-f6e0c57de503",
     "owners": [],

--- a/playbooks/06 - IRP - Case Management/Alert - [03] Capture Response SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Alert - [03] Capture Response SLA (Upon Update).json
@@ -17,121 +17,40 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Get SLA Details",
+            "name": "Set Response SLA as Missed",
             "description": null,
             "arguments": {
-                "arguments": {
-                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
-                    "inc_severity": "{{vars.input.records[0].severity.itemValue}}"
-                },
-                "apply_async": false,
-                "step_variables": {
-                    "sla_time_list": "{{vars.result.sla_time_list}}"
-                },
-                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
-            },
-            "status": null,
-            "top": "160",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-            "uuid": "3d5c1bc9-76f9-4924-b6a5-1a15eaf79637"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Start",
-            "description": null,
-            "arguments": {
-                "resource": "alerts",
-                "resources": [
-                    "alerts"
-                ],
-                "step_variables": {
-                    "input": {
-                        "records": [
-                            "{{vars.input.records[0]}}"
-                        ]
-                    },
-                    "day_today": "{{arrow.utcnow().format('dddd')}}",
-                    "prev_state": "vars.previous.data.state",
-                    "alert_severity": "{{vars.input.records[0].severity.itemValue}}"
-                },
-                "fieldbasedtrigger": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": [
-                        {
-                            "type": "object",
-                            "field": "status",
-                            "value": null,
-                            "_value": {
-                                "@id": null,
-                                "display": "",
-                                "itemValue": ""
-                            },
-                            "operator": "changed"
-                        }
-                    ]
-                }
-            },
-            "status": null,
-            "top": "30",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
-            "uuid": "8bc3c874-3ec8-4cc8-872b-194df4d2495e"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Pause Response SLA",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].respSlaStatus.itemValue == \"Awaiting Action\"}}",
+                "when": "{{vars.input.records[0].respSlaStatus.itemValue == \"Awaiting Action\" or vars.input.records[0].respSlaStatus.itemValue == \"Paused\" or vars.input.records[0].respSlaStatus.itemValue == \"NA\"}}",
                 "resource": {
-                    "respSlaStatus": "{%if vars.input.records[0].respDueDate < vars.input.records[0].modifyDate %}{{\"SLAState\" | picklist(\"Missed\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Paused\", \"@id\")}}{%endif%}",
-                    "respSLApausedon": "{{globalVars.Current_Date}}",
-                    "alertRemainingRespSLA": "{{((vars.input.records[0].respDueDate - vars.input.records[0].modifyDate)\/60) | round | int}}"
+                    "respDate": "{{globalVars.Current_Date}}",
+                    "respSlaStatus": {
+                        "id": 506,
+                        "@id": "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34",
+                        "icon": null,
+                        "@type": "Picklist",
+                        "color": "#de2020",
+                        "display": "Missed",
+                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
+                        "itemValue": "Missed",
+                        "orderIndex": 1
+                    }
                 },
                 "_showJson": false,
-                "operation": "Append",
+                "operation": "Overwrite",
                 "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
+                "tagsOperation": "OverwriteTags",
                 "collectionType": "\/api\/3\/alerts",
                 "fieldOperation": {
-                    "recordTags": "Append"
+                    "recordTags": "Overwrite"
                 },
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
-            "left": "125",
+            "top": "705",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "604cc06d-9a8b-400f-879c-eebca89b8271"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Check Current Status To Pause SLA",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Pause SLA",
-                        "step_iri": "\/api\/3\/workflow_steps\/604cc06d-9a8b-400f-879c-eebca89b8271",
-                        "condition": "{{ vars.input.records[0].status.itemValue == vars.sla_time_list.altPauseSLAOn }}",
-                        "step_name": "Pause Response SLA"
-                    },
-                    {
-                        "option": "Check Status for Response SLA",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/26872269-b541-4c95-bfd5-9b9f47aab7a1",
-                        "step_name": "Status Check for Response SLA"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "300",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "991dd833-6918-41a0-bd5a-a113fe1c1ce6"
+            "group": null,
+            "uuid": "0ca1af7d-67bc-4571-ad9b-0652382b5d1e"
         },
         {
             "@type": "WorkflowStep",
@@ -157,33 +76,83 @@
             "top": "435",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
             "uuid": "26872269-b541-4c95-bfd5-9b9f47aab7a1"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Check Response SLA Status",
+            "name": "Recalculate Response SLA",
             "description": null,
             "arguments": {
-                "conditions": [
-                    {
-                        "option": "Missed",
-                        "step_iri": "\/api\/3\/workflow_steps\/0ca1af7d-67bc-4571-ad9b-0652382b5d1e",
-                        "condition": "{{ (vars.input.records[0].respDueDate  < (vars.input.records[0].modifyDate)) }}",
-                        "step_name": "Set Response SLA as Missed"
-                    },
-                    {
-                        "option": "Met",
-                        "step_iri": "\/api\/3\/workflow_steps\/43029b0e-4f4d-416a-aaf0-bc88885155da",
-                        "condition": "{{ (vars.input.records[0].respDueDate >= (vars.input.records[0].modifyDate)) }}",
-                        "step_name": "Set Response SLA as Met"
-                    }
-                ]
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].respSlaStatus.itemValue== \"Awaiting Action\" or vars.input.records[0].respSlaStatus.itemValue== \"Paused\") and vars.input.records[0].status.itemValue != \"Closed\"}}",
+                "config": "4b6b27cf-86a5-4c5d-a7f8-0186dbc623b5",
+                "params": {
+                    "slaTime": "{% if vars.input.records[0].alertRemainingRespSLA%}{{vars.input.records[0].alertRemainingRespSLA}}{%else%}{{vars.sla_time_list.alertResTime}}{%endif%}",
+                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
+                },
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
+                "step_variables": []
             },
             "status": null,
-            "top": "570",
+            "top": "560",
+            "left": "820",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "2ff19b76-9de1-4b2f-8f87-3e10595e9285"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Resume Response SLA",
+            "description": null,
+            "arguments": {
+                "when": "{{(vars.input.records[0].respSlaStatus.itemValue== \"Awaiting Action\" or vars.input.records[0].respSlaStatus.itemValue== \"Paused\") and vars.input.records[0].status.itemValue != \"Closed\"}}",
+                "resource": {
+                    "respDueDate": "{{vars.steps.Recalculate_Response_SLA.data['sla_due_date_timestamp']}}",
+                    "respSlaStatus": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/alerts",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "37e414ef-7d67-4926-989a-4763951f643c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get SLA Details",
+            "description": null,
+            "arguments": {
+                "arguments": {
+                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
+                    "inc_severity": "{{vars.input.records[0].severity.itemValue}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "sla_time_list": "{{vars.result.sla_time_list}}"
+                },
+                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
+            },
+            "status": null,
+            "top": "160",
             "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "9a1d01ab-9e97-49e9-ac44-90c568334133"
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "3d5c1bc9-76f9-4924-b6a5-1a15eaf79637"
         },
         {
             "@type": "WorkflowStep",
@@ -219,88 +188,19 @@
             "top": "705",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
             "uuid": "43029b0e-4f4d-416a-aaf0-bc88885155da"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Set Response SLA as Missed",
+            "name": "Pause Response SLA",
             "description": null,
             "arguments": {
-                "when": "{{vars.input.records[0].respSlaStatus.itemValue == \"Awaiting Action\" or vars.input.records[0].respSlaStatus.itemValue == \"Paused\" or vars.input.records[0].respSlaStatus.itemValue == \"NA\"}}",
+                "when": "{{vars.input.records[0].respSlaStatus.itemValue == \"Awaiting Action\"}}",
                 "resource": {
-                    "respDate": "{{globalVars.Current_Date}}",
-                    "respSlaStatus": {
-                        "id": 506,
-                        "@id": "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34",
-                        "icon": null,
-                        "@type": "Picklist",
-                        "color": "#de2020",
-                        "display": "Missed",
-                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
-                        "itemValue": "Missed",
-                        "orderIndex": 1
-                    }
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "tagsOperation": "OverwriteTags",
-                "collectionType": "\/api\/3\/alerts",
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "705",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "0ca1af7d-67bc-4571-ad9b-0652382b5d1e"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Recalculate Response SLA",
-            "description": null,
-            "arguments": {
-                "name": "SLA Calculator",
-                "config": "4b6b27cf-86a5-4c5d-a7f8-0186dbc623b5",
-                "params": {
-                    "slaTime": "{% if vars.input.records[0].alertRemainingRespSLA%}{{vars.input.records[0].alertRemainingRespSLA}}{%else%}{{vars.sla_time_list.alertResTime}}{%endif%}",
-                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
-                },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "570",
-            "left": "825",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "2ff19b76-9de1-4b2f-8f87-3e10595e9285"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Resume Response SLA",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].respSlaStatus.itemValue== \"Awaiting Action\" or vars.input.records[0].respSlaStatus.itemValue== \"Paused\"}}",
-                "resource": {
-                    "respDueDate": "{{vars.steps.Recalculate_Response_SLA.data['sla_due_date_timestamp']}}",
-                    "respSlaStatus": {
-                        "id": 270,
-                        "@id": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
-                        "icon": null,
-                        "@type": "Picklist",
-                        "color": "#808080",
-                        "display": "Awaiting Action",
-                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
-                        "itemValue": "Awaiting Action",
-                        "orderIndex": 2
-                    },
-                    "respSLApausedon": "None"
+                    "respSlaStatus": "{%if vars.input.records[0].respDueDate < vars.input.records[0].modifyDate %}{{\"SLAState\" | picklist(\"Missed\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Paused\", \"@id\")}}{%endif%}",
+                    "respSLApausedon": "{{globalVars.Current_Date}}",
+                    "alertRemainingRespSLA": "{{((vars.input.records[0].respDueDate - vars.input.records[0].modifyDate)\/60) | round | int}}"
                 },
                 "_showJson": false,
                 "operation": "Append",
@@ -313,10 +213,126 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
-            "left": "825",
+            "top": "435",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "37e414ef-7d67-4926-989a-4763951f643c"
+            "group": null,
+            "uuid": "604cc06d-9a8b-400f-879c-eebca89b8271"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "resource": "alerts",
+                "resources": [
+                    "alerts"
+                ],
+                "step_variables": {
+                    "input": {
+                        "params": [],
+                        "records": [
+                            "{{vars.input.records[0]}}"
+                        ]
+                    },
+                    "day_today": "{{arrow.utcnow().format('dddd')}}",
+                    "prev_state": "vars.previous.data.state",
+                    "alert_severity": "{{vars.input.records[0].severity.itemValue}}"
+                },
+                "fieldbasedtrigger": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "object",
+                            "field": "status",
+                            "value": null,
+                            "_value": {
+                                "@id": null,
+                                "display": "",
+                                "itemValue": ""
+                            },
+                            "operator": "changed"
+                        },
+                        {
+                            "type": "array",
+                            "field": "respSlaStatus",
+                            "value": [
+                                "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                                "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34"
+                            ],
+                            "module": "respSlaStatus",
+                            "display": "",
+                            "operator": "nin",
+                            "template": "multiselectpicklist",
+                            "OPERATOR_KEY": "$",
+                            "previousOperator": "nin",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ]
+                }
+            },
+            "status": null,
+            "top": "30",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
+            "group": null,
+            "uuid": "8bc3c874-3ec8-4cc8-872b-194df4d2495e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Current Status To Pause SLA",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Pause SLA",
+                        "step_iri": "\/api\/3\/workflow_steps\/604cc06d-9a8b-400f-879c-eebca89b8271",
+                        "condition": "{{ vars.input.records[0].status.itemValue == vars.sla_time_list.altPauseSLAOn }}",
+                        "step_name": "Pause Response SLA"
+                    },
+                    {
+                        "option": "Check Status for Response SLA",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/26872269-b541-4c95-bfd5-9b9f47aab7a1",
+                        "step_name": "Status Check for Response SLA"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "300",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "991dd833-6918-41a0-bd5a-a113fe1c1ce6"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Response SLA Status",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Missed",
+                        "step_iri": "\/api\/3\/workflow_steps\/0ca1af7d-67bc-4571-ad9b-0652382b5d1e",
+                        "condition": "{{ (vars.input.records[0].respDueDate  < (vars.input.records[0].modifyDate)) }}",
+                        "step_name": "Set Response SLA as Missed"
+                    },
+                    {
+                        "option": "Met",
+                        "step_iri": "\/api\/3\/workflow_steps\/43029b0e-4f4d-416a-aaf0-bc88885155da",
+                        "condition": "{{ (vars.input.records[0].respDueDate >= (vars.input.records[0].modifyDate)) }}",
+                        "step_name": "Set Response SLA as Met"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "570",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "9a1d01ab-9e97-49e9-ac44-90c568334133"
         }
     ],
     "routes": [
@@ -402,6 +418,7 @@
             "uuid": "b242c138-8f70-45d7-95aa-889b17892ac7"
         }
     ],
+    "groups": [],
     "priority": null,
     "uuid": "4f9944be-4d65-485a-805c-95e4359acaa5",
     "owners": [],

--- a/playbooks/06 - IRP - Case Management/Alert - [05] Update Ack and Response Due dates (Post Severity Change).json
+++ b/playbooks/06 - IRP - Case Management/Alert - [05] Update Ack and Response Due dates (Post Severity Change).json
@@ -17,66 +17,29 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Start",
+            "name": "Reset Ack SLA",
             "description": null,
             "arguments": {
-                "resource": "alerts",
-                "resources": [
-                    "alerts"
-                ],
-                "step_variables": {
-                    "input": {
-                        "records": [
-                            "{{vars.input.records[0]}}"
-                        ]
-                    },
-                    "curr_severity": "{{vars.input.records[0].severity.itemValue}}"
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertAackTrackedOn)}}",
+                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
+                "params": {
+                    "slaTime": "{{vars.sla_time_list.alertAckTime}}",
+                    "recordCreateTime": "{{vars.input.records[0].createDate}}"
                 },
-                "fieldbasedtrigger": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": [
-                        {
-                            "type": "object",
-                            "field": "severity",
-                            "value": null,
-                            "_value": {
-                                "@id": null,
-                                "display": "",
-                                "itemValue": ""
-                            },
-                            "operator": "changed"
-                        }
-                    ]
-                }
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
+                "step_variables": []
             },
             "status": null,
-            "top": "30",
+            "top": "570",
             "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
-            "uuid": "d60f551c-1d9e-46cd-b62a-dca90b6049ad"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "GET Current SLA",
-            "description": null,
-            "arguments": {
-                "arguments": {
-                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
-                    "inc_severity": "{{vars.curr_severity}}"
-                },
-                "apply_async": false,
-                "step_variables": {
-                    "sla_time_list": "{{vars.result.sla_time_list}}"
-                },
-                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
-            },
-            "status": null,
-            "top": "165",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-            "uuid": "647af7c9-463a-46e2-831a-b0c0c9f2e8d5"
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "05e232b5-adba-4035-92c3-65f21e123950"
         },
         {
             "@type": "WorkflowStep",
@@ -87,7 +50,7 @@
                     {
                         "option": "Check Reset SLA Flag",
                         "step_iri": "\/api\/3\/workflow_steps\/23b54433-dc46-4eda-900d-2abca42de752",
-                        "condition": "{{ vars.sla_time_list | length > 0 }}",
+                        "condition": "{{ vars.sla_time_list | length > 0 and vars.input.records[0].status.itemValue != \"Closed\" }}",
                         "step_name": "Check SLA Reset Flag"
                     },
                     {
@@ -102,21 +65,23 @@
             "top": "300",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
             "uuid": "061f08b7-a2f5-4925-86f4-3da30d75fe32"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Reset Ack SLA",
+            "name": "Update Set Resp SLA",
             "description": null,
             "arguments": {
-                "when": "{{vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\"))or vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\")) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertAackTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
+                "when": "{{(vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
                 "resource": {
-                    "dueBy": "{%if vars.sla_time_list.alertAckTime | int ==0%} null {% elif vars.steps.Reset_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Ack_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].dueBy}} {%endif%}",
-                    "ackSlaStatus": "{%if vars.sla_time_list.alertAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
+                    "respDueDate": "{%if vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
+                    "respSlaStatus": "{%if vars.sla_time_list.alertResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
                 },
                 "_showJson": false,
                 "operation": "Overwrite",
                 "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
                 "tagsOperation": "OverwriteTags",
                 "collectionType": "\/api\/3\/alerts",
                 "fieldOperation": {
@@ -125,110 +90,11 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
-            "left": "475",
+            "top": "975",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "e2516fac-1a4a-4bcf-a07e-dbf82a8c2716"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Reset Ack SLA",
-            "description": null,
-            "arguments": {
-                "name": "SLA Calculator",
-                "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertAackTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
-                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
-                "params": {
-                    "slaTime": "{{vars.sla_time_list.alertAckTime}}",
-                    "recordCreateTime": "{{vars.input.records[0].createDate}}"
-                },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "570",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "05e232b5-adba-4035-92c3-65f21e123950"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Reset Resp SLA",
-            "description": null,
-            "arguments": {
-                "name": "SLA Calculator",
-                "when": "{{(vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertResTime | int > 0) and (vars.input.records[0].status.itemValue != alertResTrackedOn)}}",
-                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
-                "params": {
-                    "slaTime": "{{vars.sla_time_list.alertResTime}}",
-                    "recordCreateTime": "{{vars.input.records[0].createDate}}"
-                },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "840",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "fae888be-807c-403e-bb81-11f4f535973a"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Ack SLA",
-            "description": null,
-            "arguments": {
-                "name": "SLA Calculator",
-                "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertAackTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
-                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
-                "params": {
-                    "slaTime": "{{vars.sla_time_list.alertAckTime}}",
-                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
-                },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "570",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "3053358c-e749-43a4-9089-5be1d04e8d27"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Resp SLA",
-            "description": null,
-            "arguments": {
-                "name": "SLA Calculator",
-                "when": "{{(vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertResTime | int > 0) and (vars.input.records[0].status.itemValue != alertResTrackedOn)}}",
-                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
-                "params": {
-                    "slaTime": "{{vars.sla_time_list.alertResTime}}",
-                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
-                },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "840",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "6582bb18-3442-474d-8c0b-074df32c2bcc"
+            "group": null,
+            "uuid": "0f06cf5b-30b7-4bd7-9945-40ed8fe97c74"
         },
         {
             "@type": "WorkflowStep",
@@ -254,14 +120,41 @@
             "top": "435",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
             "uuid": "23b54433-dc46-4eda-900d-2abca42de752"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Ack SLA",
+            "description": null,
+            "arguments": {
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertAackTrackedOn)}}",
+                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
+                "params": {
+                    "slaTime": "{{vars.sla_time_list.alertAckTime}}",
+                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
+                },
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "3053358c-e749-43a4-9089-5be1d04e8d27"
         },
         {
             "@type": "WorkflowStep",
             "name": "Update Set Ack SLA",
             "description": null,
             "arguments": {
-                "when": "{{vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\"))or vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\")) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertAackTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
+                "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertAackTrackedOn)}}",
                 "resource": {
                     "dueBy": "{%if vars.steps.Set_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Ack_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
                     "ackSlaStatus": "{%if vars.sla_time_list.alertAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
@@ -269,6 +162,7 @@
                 "_showJson": false,
                 "operation": "Overwrite",
                 "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
                 "tagsOperation": "OverwriteTags",
                 "collectionType": "\/api\/3\/alerts",
                 "fieldOperation": {
@@ -280,59 +174,56 @@
             "top": "705",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
             "uuid": "4e28f16f-057f-428a-ad57-e98202c3bc0e"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Set Resp SLA",
+            "name": "GET Current SLA",
             "description": null,
             "arguments": {
-                "when": "{{vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\")) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
-                "resource": {
-                    "respDueDate": "{%if vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
-                    "respSlaStatus": "{%if vars.sla_time_list.alertResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
+                "arguments": {
+                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
+                    "inc_severity": "{{vars.curr_severity}}"
                 },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "tagsOperation": "OverwriteTags",
-                "collectionType": "\/api\/3\/alerts",
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
+                "apply_async": false,
+                "step_variables": {
+                    "sla_time_list": "{{vars.result.sla_time_list}}"
                 },
-                "step_variables": []
+                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
             },
             "status": null,
-            "top": "975",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "0f06cf5b-30b7-4bd7-9945-40ed8fe97c74"
+            "top": "165",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "647af7c9-463a-46e2-831a-b0c0c9f2e8d5"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Reset Resp SLA",
+            "name": "Set Resp SLA",
             "description": null,
             "arguments": {
-                "when": "{{vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\")) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
-                "resource": {
-                    "respDueDate": "{%if vars.sla_time_list.alertResTime | int ==0%} null {% elif vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].respDueDate}}{%endif%}",
-                    "respSlaStatus": "{%if vars.sla_time_list.alertResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
+                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
+                "params": {
+                    "slaTime": "{{vars.sla_time_list.alertResTime}}",
+                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
                 },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "tagsOperation": "OverwriteTags",
-                "collectionType": "\/api\/3\/alerts",
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "fec68d93-2435-42e4-9264-de0170ea3103"
+            "top": "840",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "6582bb18-3442-474d-8c0b-074df32c2bcc"
         },
         {
             "@type": "WorkflowStep",
@@ -350,7 +241,169 @@
             "top": "435",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
             "uuid": "7bf5a2fd-df77-4139-b7aa-f8e05d53fff7"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "resource": "alerts",
+                "resources": [
+                    "alerts"
+                ],
+                "step_variables": {
+                    "input": {
+                        "params": [],
+                        "records": [
+                            "{{vars.input.records[0]}}"
+                        ]
+                    },
+                    "curr_severity": "{{vars.input.records[0].severity.itemValue}}"
+                },
+                "fieldbasedtrigger": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "object",
+                            "field": "severity",
+                            "value": null,
+                            "_value": {
+                                "@id": null,
+                                "display": "",
+                                "itemValue": ""
+                            },
+                            "operator": "changed"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "type": "array",
+                                    "field": "ackSlaStatus",
+                                    "value": [
+                                        "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                                        "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34"
+                                    ],
+                                    "module": "ackSlaStatus",
+                                    "display": "",
+                                    "operator": "nin",
+                                    "template": "multiselectpicklist",
+                                    "OPERATOR_KEY": "$",
+                                    "previousOperator": "nin",
+                                    "previousTemplate": "multiselectpicklist"
+                                },
+                                {
+                                    "type": "array",
+                                    "field": "respSlaStatus",
+                                    "value": [
+                                        "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                                        "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34"
+                                    ],
+                                    "module": "respSlaStatus",
+                                    "display": "",
+                                    "operator": "nin",
+                                    "template": "multiselectpicklist",
+                                    "OPERATOR_KEY": "$",
+                                    "previousOperator": "nin",
+                                    "previousTemplate": "multiselectpicklist"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "status": null,
+            "top": "30",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
+            "group": null,
+            "uuid": "d60f551c-1d9e-46cd-b62a-dca90b6049ad"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Reset Ack SLA",
+            "description": null,
+            "arguments": {
+                "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertAackTrackedOn)}}",
+                "resource": {
+                    "dueBy": "{%if vars.sla_time_list.alertAckTime | int ==0%} null {% elif vars.steps.Reset_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Ack_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].dueBy}} {%endif%}",
+                    "ackSlaStatus": "{%if vars.sla_time_list.alertAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "tagsOperation": "OverwriteTags",
+                "collectionType": "\/api\/3\/alerts",
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "e2516fac-1a4a-4bcf-a07e-dbf82a8c2716"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Reset Resp SLA",
+            "description": null,
+            "arguments": {
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
+                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
+                "params": {
+                    "slaTime": "{{vars.sla_time_list.alertResTime}}",
+                    "recordCreateTime": "{{vars.input.records[0].createDate}}"
+                },
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "840",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "fae888be-807c-403e-bb81-11f4f535973a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Reset Resp SLA",
+            "description": null,
+            "arguments": {
+                "when": "{{(vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
+                "resource": {
+                    "respDueDate": "{%if vars.sla_time_list.alertResTime | int ==0%} null {% elif vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].respDueDate}}{%endif%}",
+                    "respSlaStatus": "{%if vars.sla_time_list.alertResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "tagsOperation": "OverwriteTags",
+                "collectionType": "\/api\/3\/alerts",
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "fec68d93-2435-42e4-9264-de0170ea3103"
         }
     ],
     "routes": [
@@ -463,6 +516,7 @@
             "uuid": "f267cf92-fd0c-481e-ab17-af68e984ed44"
         }
     ],
+    "groups": [],
     "priority": null,
     "uuid": "54afab11-6934-4b30-9c21-db43a878d2d1",
     "owners": [],

--- a/playbooks/06 - IRP - Case Management/Incident - [02] Capture Ack SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Incident - [02] Capture Ack SLA (Upon Update).json
@@ -17,208 +17,6 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Start",
-            "description": null,
-            "arguments": {
-                "resource": "incidents",
-                "resources": [
-                    "incidents"
-                ],
-                "step_variables": {
-                    "input": {
-                        "params": [],
-                        "records": [
-                            "{{vars.input.records[0]}}"
-                        ]
-                    },
-                    "day_today": "{{arrow.utcnow().format('dddd')}}",
-                    "alert_severity": "{{vars.input.records[0].severity.itemValue}}"
-                },
-                "fieldbasedtrigger": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": [
-                        {
-                            "type": "object",
-                            "field": "status",
-                            "value": null,
-                            "_value": {
-                                "@id": null,
-                                "display": "",
-                                "itemValue": ""
-                            },
-                            "operator": "changed"
-                        },
-                        {
-                            "type": "object",
-                            "field": "slaState",
-                            "value": "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
-                            "_value": {
-                                "@id": "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
-                                "display": "Met",
-                                "itemValue": "Met"
-                            },
-                            "operator": "neq"
-                        }
-                    ]
-                }
-            },
-            "status": null,
-            "top": "20",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
-            "uuid": "30d0563e-fdaf-4ebd-b165-1b2c1437e5ad"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get SLA Details",
-            "description": null,
-            "arguments": {
-                "arguments": {
-                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
-                    "inc_severity": "{{vars.input.records[0].severity.itemValue}}"
-                },
-                "apply_async": false,
-                "step_variables": {
-                    "sla_time_list": "{{vars.result.sla_time_list}}"
-                },
-                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
-            },
-            "status": null,
-            "top": "165",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-            "uuid": "2fab9997-d562-4381-8564-145d598ec3c9"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Check Current Status To Pause SLA",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Pause SLA",
-                        "step_iri": "\/api\/3\/workflow_steps\/fc727bbd-5a5e-4491-946b-b8b81528a583",
-                        "condition": "{{ vars.input.records[0].status.itemValue == vars.sla_time_list.incPauseSLAOn }}",
-                        "step_name": "Pause SLA"
-                    },
-                    {
-                        "option": "Check Status for Ack SLA",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/3602c56d-f354-4c9d-a7c9-48b1f29d8ae1",
-                        "step_name": "Status Check for Ack SLA"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "300",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "86b82625-d92a-4cdd-ad9a-78067d57ea3c"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Pause Ack SLA",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].slaState.itemValue == \"Awaiting Action\"}}",
-                "resource": {
-                    "resSla": {
-                        "id": 331,
-                        "@id": "\/api\/3\/picklists\/3f4ef2dc-7f56-4886-b215-ee08b344cbdf",
-                        "icon": null,
-                        "uuid": "3f4ef2dc-7f56-4886-b215-ee08b344cbdf",
-                        "@type": "Picklist",
-                        "color": "#ffcc00",
-                        "display": "Paused",
-                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
-                        "itemValue": "Paused",
-                        "orderIndex": 4
-                    },
-                    "slaState": "{% if vars.input.records[0].ackDueDate < vars.input.records[0].modifyDate%}{{\"SLAState\" | picklist(\"Missed\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Paused\", \"@id\")}}{%endif%}",
-                    "ackSLApausedon": "{{globalVars.Current_Date}}",
-                    "incRemainingAckSLA": "{{((vars.input.records[0].ackDueDate - vars.input.records[0].modifyDate)\/60) | round | int}}"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/incidents",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "440",
-            "left": "120",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "fc727bbd-5a5e-4491-946b-b8b81528a583"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Recalculate Ack SLA",
-            "description": null,
-            "arguments": {
-                "name": "SLA Calculator",
-                "config": "4b6b27cf-86a5-4c5d-a7f8-0186dbc623b5",
-                "params": {
-                    "slaTime": "{%if vars.input.records[0].incRemainingAckSLA %}{{vars.input.records[0].incRemainingAckSLA}}{%else%}{{vars.sla_time_list.incAckTime}}{%endif%}",
-                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
-                },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "560",
-            "left": "120",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "238bddf9-363e-4bef-b65e-2ef967dcd906"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Resume Ack SLA",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].slaState.itemValue== \"Awaiting Action\" or vars.input.records[0].slaState.itemValue == \"Paused\"}}",
-                "resource": {
-                    "slaState": {
-                        "id": 289,
-                        "@id": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
-                        "icon": null,
-                        "uuid": "72979f64-e8b9-4888-a965-957e0ec24818",
-                        "@type": "Picklist",
-                        "color": "#808080",
-                        "display": "Awaiting Action",
-                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
-                        "itemValue": "Awaiting Action",
-                        "orderIndex": 2
-                    },
-                    "ackDueDate": "{{vars.steps.Recalculate_Ack_SLA.data['sla_due_date_timestamp']}}"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/incidents",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "700",
-            "left": "120",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "409bd131-6c4c-4c2e-99e0-85b4837bd244"
-        },
-        {
-            "@type": "WorkflowStep",
             "name": "Set Acknowledge SLA as Missed",
             "description": null,
             "arguments": {
@@ -253,33 +51,8 @@
             "top": "700",
             "left": "820",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
             "uuid": "2259dc78-7165-4d08-8285-8e1831c67928"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Check Acknowledge SLA Status",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Missed",
-                        "step_iri": "\/api\/3\/workflow_steps\/2259dc78-7165-4d08-8285-8e1831c67928",
-                        "condition": "{{ vars.input.records[0].modifyDate > vars.input.records[0].ackDueDate }}",
-                        "step_name": "Set Acknowledge SLA as Missed"
-                    },
-                    {
-                        "option": "Met",
-                        "step_iri": "\/api\/3\/workflow_steps\/22cda60d-caa6-4a99-8151-7b9daf88cb4c",
-                        "condition": "{{ vars.input.records[0].modifyDate < vars.input.records[0].ackDueDate }}",
-                        "step_name": "Set Acknowledge SLA as Met"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "560",
-            "left": "640",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "d1d2ffdc-dcfb-4309-8274-dee947f8ea88"
         },
         {
             "@type": "WorkflowStep",
@@ -318,7 +91,117 @@
             "top": "700",
             "left": "480",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
             "uuid": "22cda60d-caa6-4a99-8151-7b9daf88cb4c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Recalculate Ack SLA",
+            "description": null,
+            "arguments": {
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].slaState.itemValue == \"Awaiting Action\" or vars.input.records[0].slaState.itemValue == \"Paused\" ) and vars.input.records[0].status.itemValue != \"Closed\"}}",
+                "config": "4b6b27cf-86a5-4c5d-a7f8-0186dbc623b5",
+                "params": {
+                    "slaTime": "{%if vars.input.records[0].incRemainingAckSLA %}{{vars.input.records[0].incRemainingAckSLA}}{%else%}{{vars.sla_time_list.incAckTime}}{%endif%}",
+                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
+                },
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "560",
+            "left": "120",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "238bddf9-363e-4bef-b65e-2ef967dcd906"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get SLA Details",
+            "description": null,
+            "arguments": {
+                "arguments": {
+                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
+                    "inc_severity": "{{vars.input.records[0].severity.itemValue}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "sla_time_list": "{{vars.result.sla_time_list}}"
+                },
+                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
+            },
+            "status": null,
+            "top": "165",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "2fab9997-d562-4381-8564-145d598ec3c9"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "resource": "incidents",
+                "resources": [
+                    "incidents"
+                ],
+                "step_variables": {
+                    "input": {
+                        "params": [],
+                        "records": [
+                            "{{vars.input.records[0]}}"
+                        ]
+                    },
+                    "day_today": "{{arrow.utcnow().format('dddd')}}",
+                    "alert_severity": "{{vars.input.records[0].severity.itemValue}}"
+                },
+                "fieldbasedtrigger": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "object",
+                            "field": "status",
+                            "value": null,
+                            "_value": {
+                                "@id": null,
+                                "display": "",
+                                "itemValue": ""
+                            },
+                            "operator": "changed"
+                        },
+                        {
+                            "type": "object",
+                            "field": "slaState",
+                            "value": [
+                                "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                                "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34"
+                            ],
+                            "module": "slaState",
+                            "display": "Met",
+                            "operator": "nin",
+                            "template": "multiselectpicklist",
+                            "OPERATOR_KEY": "$",
+                            "displayTemplate": "",
+                            "previousOperator": "nin",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ]
+                }
+            },
+            "status": null,
+            "top": "20",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
+            "group": null,
+            "uuid": "30d0563e-fdaf-4ebd-b165-1b2c1437e5ad"
         },
         {
             "@type": "WorkflowStep",
@@ -344,7 +227,129 @@
             "top": "440",
             "left": "480",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
             "uuid": "3602c56d-f354-4c9d-a7c9-48b1f29d8ae1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Resume Ack SLA",
+            "description": null,
+            "arguments": {
+                "when": "{{(vars.input.records[0].slaState.itemValue == \"Awaiting Action\" or vars.input.records[0].slaState.itemValue == \"Paused\" ) and vars.input.records[0].status.itemValue != \"Closed\"}}",
+                "resource": {
+                    "slaState": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
+                    "ackDueDate": "{{vars.steps.Recalculate_Ack_SLA.data['sla_due_date_timestamp']}}"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/incidents",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "700",
+            "left": "120",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "409bd131-6c4c-4c2e-99e0-85b4837bd244"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Current Status To Pause SLA",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Pause SLA",
+                        "step_iri": "\/api\/3\/workflow_steps\/fc727bbd-5a5e-4491-946b-b8b81528a583",
+                        "condition": "{{ vars.input.records[0].status.itemValue == vars.sla_time_list.incPauseSLAOn }}",
+                        "step_name": "Pause SLA"
+                    },
+                    {
+                        "option": "Check Status for Ack SLA",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/3602c56d-f354-4c9d-a7c9-48b1f29d8ae1",
+                        "step_name": "Status Check for Ack SLA"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "300",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "86b82625-d92a-4cdd-ad9a-78067d57ea3c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Acknowledge SLA Status",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Missed",
+                        "step_iri": "\/api\/3\/workflow_steps\/2259dc78-7165-4d08-8285-8e1831c67928",
+                        "condition": "{{ vars.input.records[0].modifyDate > vars.input.records[0].ackDueDate }}",
+                        "step_name": "Set Acknowledge SLA as Missed"
+                    },
+                    {
+                        "option": "Met",
+                        "step_iri": "\/api\/3\/workflow_steps\/22cda60d-caa6-4a99-8151-7b9daf88cb4c",
+                        "condition": "{{ vars.input.records[0].modifyDate < vars.input.records[0].ackDueDate }}",
+                        "step_name": "Set Acknowledge SLA as Met"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "560",
+            "left": "640",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "d1d2ffdc-dcfb-4309-8274-dee947f8ea88"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Pause Ack SLA",
+            "description": null,
+            "arguments": {
+                "when": "{{vars.input.records[0].slaState.itemValue == \"Awaiting Action\"}}",
+                "resource": {
+                    "resSla": {
+                        "id": 331,
+                        "@id": "\/api\/3\/picklists\/3f4ef2dc-7f56-4886-b215-ee08b344cbdf",
+                        "icon": null,
+                        "uuid": "3f4ef2dc-7f56-4886-b215-ee08b344cbdf",
+                        "@type": "Picklist",
+                        "color": "#ffcc00",
+                        "display": "Paused",
+                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
+                        "itemValue": "Paused",
+                        "orderIndex": 4
+                    },
+                    "slaState": "{% if vars.input.records[0].ackDueDate < vars.input.records[0].modifyDate%}{{\"SLAState\" | picklist(\"Missed\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Paused\", \"@id\")}}{%endif%}",
+                    "ackSLApausedon": "{{globalVars.Current_Date}}",
+                    "incRemainingAckSLA": "{{((vars.input.records[0].ackDueDate - vars.input.records[0].modifyDate)\/60) | round | int}}"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/incidents",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "440",
+            "left": "120",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "fc727bbd-5a5e-4491-946b-b8b81528a583"
         }
     ],
     "routes": [
@@ -430,6 +435,7 @@
             "uuid": "3f2fa94c-e38e-4fbc-98d6-6cc5b4dd4ef4"
         }
     ],
+    "groups": [],
     "priority": null,
     "uuid": "9e14d9ea-bcd1-46d5-965e-42bdc8918a59",
     "owners": [],

--- a/playbooks/06 - IRP - Case Management/Incident - [03] Capture Response SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Incident - [03] Capture Response SLA (Upon Update).json
@@ -17,6 +17,202 @@
     "steps": [
         {
             "@type": "WorkflowStep",
+            "name": "Set Response SLA as Met",
+            "description": null,
+            "arguments": {
+                "when": "{{vars.input.records[0].resSla.itemValue == \"Awaiting Action\" or vars.input.records[0].resSla.itemValue == \"Paused\" or vars.input.records[0].resSla.itemValue == \"NA\"}}",
+                "resource": {
+                    "resSla": {
+                        "id": 7,
+                        "@id": "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                        "icon": null,
+                        "uuid": "090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                        "@type": "Picklist",
+                        "color": "#14b341",
+                        "display": "Met",
+                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
+                        "itemValue": "Met",
+                        "orderIndex": 0
+                    },
+                    "resDate": "{{globalVars.Current_Date}}"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "tagsOperation": "OverwriteTags",
+                "collectionType": "\/api\/3\/incidents",
+                "fieldOperation": {
+                    "category": "Append",
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "15caf55e-1724-4104-88a2-21883463a9d1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Current Status To Pause SLA",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Pause SLA",
+                        "step_iri": "\/api\/3\/workflow_steps\/e0ddd7b3-2cb8-4394-b7ea-75eb7baa7194",
+                        "condition": "{{ vars.input.records[0].status.itemValue == vars.sla_time_list.incPauseSLAOn }}",
+                        "step_name": "Pause Response SLA"
+                    },
+                    {
+                        "option": "Check Status for Ack SLA",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/9fd6895c-66ab-4855-8554-f929009b3d4d",
+                        "step_name": "Status Check for Ack SLA"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "300",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "25606b7b-c97b-4be6-8b56-55b9b6cbddbd"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Resume Response SLA",
+            "description": null,
+            "arguments": {
+                "when": "{{(vars.input.records[0].resSla.itemValue== \"Awaiting Action\" or vars.input.records[0].resSla.itemValue== \"Paused\") and vars.input.records[0].status.itemValue != \"Closed\"}}",
+                "resource": {
+                    "resSla": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
+                    "resDueBy": "{{vars.steps.Recalculate_Response_SLA.data['sla_due_date_timestamp']}}"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/incidents",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "34b205ba-89d0-4bd9-8767-c3b9bd3a08fa"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get SLA Details",
+            "description": null,
+            "arguments": {
+                "arguments": {
+                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
+                    "inc_severity": "{{vars.input.records[0].severity.itemValue}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "sla_time_list": "{{vars.result.sla_time_list}}"
+                },
+                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
+            },
+            "status": null,
+            "top": "165",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "37dc8faa-6419-4435-a6cb-53d142ed3905"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Recalculate Response SLA",
+            "description": null,
+            "arguments": {
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].resSla.itemValue== \"Awaiting Action\" or vars.input.records[0].resSla.itemValue== \"Paused\") and vars.input.records[0].status.itemValue != \"Closed\"}}",
+                "config": "4b6b27cf-86a5-4c5d-a7f8-0186dbc623b5",
+                "params": {
+                    "slaTime": "{%if vars.input.records[0].incRemainingAckSLA %}{{vars.input.records[0].incRemainingAckSLA}}{%else%}{{vars.sla_time_list.incAckTime}}{%endif%}",
+                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
+                },
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "5cd621a4-48cf-4640-be70-0ab64384a93b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Status Check for Response SLA",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Set Response Date",
+                        "step_iri": "\/api\/3\/workflow_steps\/a4bb2298-e229-4712-bff2-c7d9caaf1ccb",
+                        "condition": "{{ vars.input.records[0].status.itemValue == vars.steps.Get_SLA_Details.sla_time_list.incResTrackedOn }}",
+                        "step_name": "Check Acknowledge SLA Status"
+                    },
+                    {
+                        "option": "Recalculate Response SLA",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/5cd621a4-48cf-4640-be70-0ab64384a93b",
+                        "step_name": "Recalculate Ack SLA"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "435",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "9fd6895c-66ab-4855-8554-f929009b3d4d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Response SLA Status",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Missed",
+                        "step_iri": "\/api\/3\/workflow_steps\/f31767a6-f915-4be7-9b36-12a289011e4a",
+                        "condition": "{{ vars.input.records[0].modifyDate > vars.input.records[0].resDueBy }}",
+                        "step_name": "Set Response SLA as Missed"
+                    },
+                    {
+                        "option": "Met",
+                        "step_iri": "\/api\/3\/workflow_steps\/15caf55e-1724-4104-88a2-21883463a9d1",
+                        "condition": "{{ vars.input.records[0].modifyDate < vars.input.records[0].resDueBy }}",
+                        "step_name": "Set Response SLA as Met"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "570",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "a4bb2298-e229-4712-bff2-c7d9caaf1ccb"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Start",
             "description": null,
             "arguments": {
@@ -49,6 +245,22 @@
                                 "itemValue": ""
                             },
                             "operator": "changed"
+                        },
+                        {
+                            "type": "object",
+                            "field": "resSla",
+                            "value": [
+                                "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                                "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34"
+                            ],
+                            "module": "resSla",
+                            "display": "",
+                            "operator": "nin",
+                            "template": "multiselectpicklist",
+                            "OPERATOR_KEY": "$",
+                            "displayTemplate": "",
+                            "previousOperator": "nin",
+                            "previousTemplate": "multiselectpicklist"
                         }
                     ]
                 }
@@ -57,7 +269,36 @@
             "top": "30",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
+            "group": null,
             "uuid": "d387ac60-b1af-4c65-84e2-f7c0ff236314"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Pause Response SLA",
+            "description": null,
+            "arguments": {
+                "when": "{{vars.input.records[0].resSla.itemValue == \"Awaiting Action\"}}",
+                "resource": {
+                    "resSla": "{%if vars.input.records[0].resDueBy < vars.input.records[0].modifyDate %}{{\"SLAState\" | picklist(\"Missed\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Paused\", \"@id\")}}{%endif%}",
+                    "respSLApausedon": "{{globalVars.Current_Date}}",
+                    "incRemainingRespSLA": "{{((vars.input.records[0].resDueBy - vars.input.records[0].modifyDate)\/60) | round | int}}"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/incidents",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "e0ddd7b3-2cb8-4394-b7ea-75eb7baa7194"
         },
         {
             "@type": "WorkflowStep",
@@ -95,233 +336,8 @@
             "top": "705",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
             "uuid": "f31767a6-f915-4be7-9b36-12a289011e4a"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Response SLA as Met",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].resSla.itemValue == \"Awaiting Action\" or vars.input.records[0].resSla.itemValue == \"Paused\" or vars.input.records[0].resSla.itemValue == \"NA\"}}",
-                "resource": {
-                    "resSla": {
-                        "id": 7,
-                        "@id": "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
-                        "icon": null,
-                        "uuid": "090115d7-90fc-4dc6-97ca-27950fc30c1c",
-                        "@type": "Picklist",
-                        "color": "#14b341",
-                        "display": "Met",
-                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
-                        "itemValue": "Met",
-                        "orderIndex": 0
-                    },
-                    "resDate": "{{globalVars.Current_Date}}"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
-                "tagsOperation": "OverwriteTags",
-                "collectionType": "\/api\/3\/incidents",
-                "fieldOperation": {
-                    "category": "Append",
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "705",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "15caf55e-1724-4104-88a2-21883463a9d1"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Resume Response SLA",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].resSla.itemValue== \"Awaiting Action\" or vars.input.records[0].resSla.itemValue == \"Paused\"}}",
-                "resource": {
-                    "resSla": {
-                        "id": 289,
-                        "@id": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
-                        "icon": null,
-                        "uuid": "72979f64-e8b9-4888-a965-957e0ec24818",
-                        "@type": "Picklist",
-                        "color": "#808080",
-                        "display": "Awaiting Action",
-                        "listName": "\/api\/3\/picklist_names\/fe36a8f2-fcba-4221-b4ab-1081f596b153",
-                        "itemValue": "Awaiting Action",
-                        "orderIndex": 2
-                    },
-                    "resDueBy": "{{vars.steps.Recalculate_Response_SLA.data['sla_due_date_timestamp']}}"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/incidents",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "705",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "34b205ba-89d0-4bd9-8767-c3b9bd3a08fa"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Recalculate Response SLA",
-            "description": null,
-            "arguments": {
-                "name": "SLA Calculator",
-                "config": "4b6b27cf-86a5-4c5d-a7f8-0186dbc623b5",
-                "params": {
-                    "slaTime": "{%if vars.input.records[0].incRemainingAckSLA %}{{vars.input.records[0].incRemainingAckSLA}}{%else%}{{vars.sla_time_list.incAckTime}}{%endif%}",
-                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
-                },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "570",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "5cd621a4-48cf-4640-be70-0ab64384a93b"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Check Response SLA Status",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Missed",
-                        "step_iri": "\/api\/3\/workflow_steps\/f31767a6-f915-4be7-9b36-12a289011e4a",
-                        "condition": "{{ vars.input.records[0].modifyDate > vars.input.records[0].resDueBy }}",
-                        "step_name": "Set Response SLA as Missed"
-                    },
-                    {
-                        "option": "Met",
-                        "step_iri": "\/api\/3\/workflow_steps\/15caf55e-1724-4104-88a2-21883463a9d1",
-                        "condition": "{{ vars.input.records[0].modifyDate < vars.input.records[0].resDueBy }}",
-                        "step_name": "Set Response SLA as Met"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "570",
-            "left": "650",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "a4bb2298-e229-4712-bff2-c7d9caaf1ccb"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Status Check for Response SLA",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Set Response Date",
-                        "step_iri": "\/api\/3\/workflow_steps\/a4bb2298-e229-4712-bff2-c7d9caaf1ccb",
-                        "condition": "{{ vars.input.records[0].status.itemValue == vars.steps.Get_SLA_Details.sla_time_list.incResTrackedOn }}",
-                        "step_name": "Check Acknowledge SLA Status"
-                    },
-                    {
-                        "option": "Recalculate Response SLA",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/5cd621a4-48cf-4640-be70-0ab64384a93b",
-                        "step_name": "Recalculate Ack SLA"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "435",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "9fd6895c-66ab-4855-8554-f929009b3d4d"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Pause Response SLA",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].resSla.itemValue == \"Awaiting Action\"}}",
-                "resource": {
-                    "resSla": "{%if vars.input.records[0].resDueBy < vars.input.records[0].modifyDate %}{{\"SLAState\" | picklist(\"Missed\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Paused\", \"@id\")}}{%endif%}",
-                    "respSLApausedon": "{{globalVars.Current_Date}}",
-                    "incRemainingRespSLA": "{{((vars.input.records[0].resDueBy - vars.input.records[0].modifyDate)\/60) | round | int}}"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/incidents",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "435",
-            "left": "825",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "e0ddd7b3-2cb8-4394-b7ea-75eb7baa7194"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Check Current Status To Pause SLA",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Pause SLA",
-                        "step_iri": "\/api\/3\/workflow_steps\/e0ddd7b3-2cb8-4394-b7ea-75eb7baa7194",
-                        "condition": "{{ vars.input.records[0].status.itemValue == vars.sla_time_list.incPauseSLAOn }}",
-                        "step_name": "Pause Response SLA"
-                    },
-                    {
-                        "option": "Check Status for Ack SLA",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/9fd6895c-66ab-4855-8554-f929009b3d4d",
-                        "step_name": "Status Check for Ack SLA"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "300",
-            "left": "650",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "uuid": "25606b7b-c97b-4be6-8b56-55b9b6cbddbd"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get SLA Details",
-            "description": null,
-            "arguments": {
-                "arguments": {
-                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
-                    "inc_severity": "{{vars.input.records[0].severity.itemValue}}"
-                },
-                "apply_async": false,
-                "step_variables": {
-                    "sla_time_list": "{{vars.result.sla_time_list}}"
-                },
-                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
-            },
-            "status": null,
-            "top": "165",
-            "left": "650",
-            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-            "uuid": "37dc8faa-6419-4435-a6cb-53d142ed3905"
         }
     ],
     "routes": [
@@ -407,6 +423,7 @@
             "uuid": "a332d010-70fc-42d1-85b0-9c7b3d310dc7"
         }
     ],
+    "groups": [],
     "priority": null,
     "uuid": "744ef7a0-d4b9-402d-8b42-82b8d94e8678",
     "owners": [],

--- a/playbooks/06 - IRP - Case Management/Incident - [05] Update Response and Ack Due date (Post Severity Change).json
+++ b/playbooks/06 - IRP - Case Management/Incident - [05] Update Response and Ack Due date (Post Severity Change).json
@@ -17,6 +17,47 @@
     "steps": [
         {
             "@type": "WorkflowStep",
+            "name": "No SLA Details Fetched",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.0.4",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "03fafd74-fbe0-4388-8745-67bf8a39d307"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "GET Current SLA",
+            "description": null,
+            "arguments": {
+                "arguments": {
+                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
+                    "inc_severity": "{{vars.curr_severity}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "sla_time_list": "{{vars.result.sla_time_list}}"
+                },
+                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
+            },
+            "status": null,
+            "top": "165",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "16f80468-3baa-4605-94c0-5d4bb92923b1"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Start",
             "description": null,
             "arguments": {
@@ -26,6 +67,7 @@
                 ],
                 "step_variables": {
                     "input": {
+                        "params": [],
                         "records": [
                             "{{vars.input.records[0]}}"
                         ]
@@ -47,6 +89,43 @@
                                 "itemValue": ""
                             },
                             "operator": "changed"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "type": "object",
+                                    "field": "slaState",
+                                    "value": [
+                                        "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                                        "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34"
+                                    ],
+                                    "module": "slaState",
+                                    "display": "",
+                                    "operator": "nin",
+                                    "template": "multiselectpicklist",
+                                    "OPERATOR_KEY": "$",
+                                    "displayTemplate": "",
+                                    "previousOperator": "nin",
+                                    "previousTemplate": "multiselectpicklist"
+                                },
+                                {
+                                    "type": "object",
+                                    "field": "resSla",
+                                    "value": [
+                                        "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
+                                        "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34"
+                                    ],
+                                    "module": "resSla",
+                                    "display": "",
+                                    "operator": "nin",
+                                    "template": "multiselectpicklist",
+                                    "OPERATOR_KEY": "$",
+                                    "displayTemplate": "",
+                                    "previousOperator": "nin",
+                                    "previousTemplate": "multiselectpicklist"
+                                }
+                            ]
                         }
                     ]
                 }
@@ -55,28 +134,8 @@
             "top": "30",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
+            "group": null,
             "uuid": "25b4e569-d398-4fc0-98fc-d39e70ec638a"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "GET Current SLA",
-            "description": null,
-            "arguments": {
-                "arguments": {
-                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
-                    "inc_severity": "{{vars.curr_severity}}"
-                },
-                "apply_async": false,
-                "step_variables": {
-                    "sla_time_list": "{{vars.result.sla_time_list}}"
-                },
-                "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
-            },
-            "status": null,
-            "top": "165",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-            "uuid": "16f80468-3baa-4605-94c0-5d4bb92923b1"
         },
         {
             "@type": "WorkflowStep",
@@ -87,13 +146,13 @@
                     {
                         "option": "Check SLA Reset Flag",
                         "step_iri": "\/api\/3\/workflow_steps\/dba70954-cf03-4cfa-8161-112d123ea2d4",
-                        "condition": "{{ vars.sla_time_list | length > 0 }}",
+                        "condition": "{{ vars.sla_time_list | length > 0 and vars.input.records[0].status.itemValue != \"Closed\" }}",
                         "step_name": "Check SLA Reset Flag"
                     },
                     {
                         "option": "Not Fetched",
                         "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/",
+                        "step_iri": "\/api\/3\/workflow_steps\/03fafd74-fbe0-4388-8745-67bf8a39d307",
                         "step_name": "No SLA Details Fetched"
                     }
                 ]
@@ -102,14 +161,122 @@
             "top": "300",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
             "uuid": "50469e45-1eb1-4fe5-94e5-a1f0f7cfc273"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Reset Ack SLA",
+            "description": null,
+            "arguments": {
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incAckTrackedOn)}}",
+                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
+                "params": {
+                    "slaTime": "{{vars.sla_time_list.incAckTime}}",
+                    "recordCreateTime": "{{vars.input.records[0].createDate}}"
+                },
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "77a22a5f-a0c2-4bf2-a0e2-c3e10511ace6"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Ack SLA",
+            "description": null,
+            "arguments": {
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incAckTrackedOn)}}",
+                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
+                "params": {
+                    "slaTime": "{{vars.sla_time_list.incAckTime}}",
+                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
+                },
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "7a32aa12-cba1-4c0e-b030-92fb0aaa5621"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Resp SLA",
+            "description": null,
+            "arguments": {
+                "name": "SLA Calculator",
+                "when": "{{(vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
+                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
+                "params": {
+                    "slaTime": "{{vars.sla_time_list.incResTime}}",
+                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
+                },
+                "version": "2.0.0",
+                "connector": "slacalculator",
+                "operation": "calculateSLA",
+                "operationTitle": "Calculate SLA",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "840",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "84f7da84-5b88-4944-b2b0-0453060c18b5"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Reset resp SLA",
+            "description": null,
+            "arguments": {
+                "when": "{{(vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
+                "resource": {
+                    "resSla": "{%if vars.sla_time_list.incResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
+                    "resDueBy": "{%if vars.sla_time_list.incResTime | int ==0%} null {% elif vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].resDueBy}} {%endif%}"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "tagsOperation": "OverwriteTags",
+                "collectionType": "\/api\/3\/incidents",
+                "fieldOperation": {
+                    "category": "Append",
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "97e23efa-dc91-4d2f-8897-b3d0862f05a0"
         },
         {
             "@type": "WorkflowStep",
             "name": "Update Reset Ack SLA",
             "description": null,
             "arguments": {
-                "when": "{{vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\"))or vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\")) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incAckTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
+                "when": "{{(vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incAckTrackedOn)}}",
                 "resource": {
                     "slaState": "{%if vars.sla_time_list.incAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
                     "ackDueDate": "{%if vars.sla_time_list.incAckTime | int ==0%} null {% elif vars.steps.Reset_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Ack_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].ackDueDate}} {%endif%}"
@@ -117,6 +284,7 @@
                 "_showJson": false,
                 "operation": "Overwrite",
                 "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
                 "tagsOperation": "OverwriteTags",
                 "collectionType": "\/api\/3\/incidents",
                 "fieldOperation": {
@@ -129,32 +297,66 @@
             "top": "705",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
             "uuid": "ab89bbee-4eea-4eb5-af32-0a804f81ed2d"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Reset Resp SLA",
+            "name": "Update Set Resp SLA",
             "description": null,
             "arguments": {
-                "name": "SLA Calculator",
-                "when": "{{(vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\"))or vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
-                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
-                "params": {
-                    "slaTime": "{{vars.sla_time_list.incResTime}}",
-                    "recordCreateTime": "{{vars.input.records[0].createDate}}"
+                "when": "{{(vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
+                "resource": {
+                    "resSla": "{%if vars.sla_time_list.incResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
+                    "resDueBy": "{%if vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}"
                 },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "tagsOperation": "OverwriteTags",
+                "collectionType": "\/api\/3\/incidents",
+                "fieldOperation": {
+                    "category": "Append",
+                    "recordTags": "Overwrite"
+                },
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "dddd9017-05b3-47b4-b035-833b6ed43e8f"
+            "top": "975",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "ac414e32-265f-434a-91a8-fee47e7da71f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Set Ack SLA",
+            "description": null,
+            "arguments": {
+                "when": "{{(vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incAckTrackedOn)}}",
+                "resource": {
+                    "slaState": "{%if vars.sla_time_list.incAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
+                    "ackDueDate": "{%if vars.steps.Set_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Ack_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "tagsOperation": "OverwriteTags",
+                "collectionType": "\/api\/3\/incidents",
+                "fieldOperation": {
+                    "category": "Append",
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "ad9e0055-fa25-430a-9e61-daa884090c06"
         },
         {
             "@type": "WorkflowStep",
@@ -180,71 +382,22 @@
             "top": "435",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
             "uuid": "dba70954-cf03-4cfa-8161-112d123ea2d4"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Reset Ack SLA",
+            "name": "Reset Resp SLA",
             "description": null,
             "arguments": {
                 "name": "SLA Calculator",
-                "when": "{{(vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incAckTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
-                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
-                "params": {
-                    "slaTime": "{{vars.sla_time_list.incAckTime}}",
-                    "recordCreateTime": "{{vars.input.records[0].createDate}}"
-                },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "570",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "77a22a5f-a0c2-4bf2-a0e2-c3e10511ace6"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Ack SLA",
-            "description": null,
-            "arguments": {
-                "name": "SLA Calculator",
-                "when": "{{(vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incAckTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
-                "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
-                "params": {
-                    "slaTime": "{{vars.sla_time_list.incAckTime}}",
-                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
-                },
-                "version": "1.0.0",
-                "connector": "slacalculator",
-                "operation": "calculateSLA",
-                "operationTitle": "Calculate SLA",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "570",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "7a32aa12-cba1-4c0e-b030-92fb0aaa5621"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Resp SLA",
-            "description": null,
-            "arguments": {
-                "name": "SLA Calculator",
-                "when": "{{(vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\"))or vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
+                "when": "{{(vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
                 "config": "c5c41701-85bc-477e-a06d-8daf36efa14a",
                 "params": {
                     "slaTime": "{{vars.sla_time_list.incResTime}}",
-                    "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
+                    "recordCreateTime": "{{vars.input.records[0].createDate}}"
                 },
-                "version": "1.0.0",
+                "version": "2.0.0",
                 "connector": "slacalculator",
                 "operation": "calculateSLA",
                 "operationTitle": "Calculate SLA",
@@ -253,108 +406,10 @@
             },
             "status": null,
             "top": "840",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "uuid": "84f7da84-5b88-4944-b2b0-0453060c18b5"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Set Ack SLA",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\"))or vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\")) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incAckTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
-                "resource": {
-                    "slaState": "{%if vars.sla_time_list.incAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
-                    "ackDueDate": "{%if vars.steps.Set_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Ack_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "tagsOperation": "OverwriteTags",
-                "collectionType": "\/api\/3\/incidents",
-                "fieldOperation": {
-                    "category": "Append",
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "705",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "ad9e0055-fa25-430a-9e61-daa884090c06"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Set Resp SLA",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\"))or vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\")) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
-                "resource": {
-                    "resSla": "{%if vars.sla_time_list.incResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
-                    "resDueBy": "{%if vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "tagsOperation": "OverwriteTags",
-                "collectionType": "\/api\/3\/incidents",
-                "fieldOperation": {
-                    "category": "Append",
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "975",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "ac414e32-265f-434a-91a8-fee47e7da71f"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update Reset resp SLA",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\"))or vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\")) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
-                "resource": {
-                    "resSla": "{%if vars.sla_time_list.incResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
-                    "resDueBy": "{%if vars.sla_time_list.incResTime | int ==0%} null {% elif vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].resDueBy}} {%endif%}"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.records[0]['@id']}}",
-                "tagsOperation": "OverwriteTags",
-                "collectionType": "\/api\/3\/incidents",
-                "fieldOperation": {
-                    "category": "Append",
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "975",
             "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "uuid": "97e23efa-dc91-4d2f-8897-b3d0862f05a0"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "No SLA Details Fetched",
-            "description": null,
-            "arguments": {
-                "params": [],
-                "version": "3.0.4",
-                "connector": "cyops_utilities",
-                "operation": "no_op",
-                "operationTitle": "Utils: No Operation",
-                "step_variables": []
-            },
-            "status": null,
-            "top": "435",
-            "left": "650",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "uuid": "03fafd74-fbe0-4388-8745-67bf8a39d307"
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "dddd9017-05b3-47b4-b035-833b6ed43e8f"
         }
     ],
     "routes": [
@@ -467,6 +522,7 @@
             "uuid": "0b6bacae-8405-4b76-92ff-d55752807f9f"
         }
     ],
+    "groups": [],
     "priority": null,
     "uuid": "be1940ec-a012-4dd0-9f9c-279da8787362",
     "owners": [],


### PR DESCRIPTION
BugFix 0848269: SLA Playbooks - Handle race condition on Update Alert severity

1. Added following onupdate condition in "Alert - [02] Capture Ack SLA (Upon Update)" , "Alert - [03] Capture Response SLA (Upon Update)" , "Alert - [05] Update Ack and Response Due dates (Post Severity Change)", "Incident - [02] Capture Ack SLA (Upon Update)" , "Incident - [03] Capture Response SLA (Upon Update)" and "Incident - [05] Update Ack and Response Due dates (Post Severity Change)" playbooks
   > Ack SLA Is Not In List [Met, Missed] in Ack playbooks
   > Response SLA Is Not In List [Met, Missed] in Response playbooks
2. Modified some conditions in above playbooks for "Recalculate/Resume  Ack /Response SLA" step