### PR TITLE
BugFix-0851660

### DIFF
--- a/playbooks/06 - IRP - Case Management/Incident - [03] Capture Response SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Incident - [03] Capture Response SLA (Upon Update).json
@@ -140,7 +140,7 @@
                 "when": "{{(vars.input.records[0].resSla.itemValue== \"Awaiting Action\" or vars.input.records[0].resSla.itemValue== \"Paused\") and vars.input.records[0].status.itemValue != \"Closed\"}}",
                 "config": "4b6b27cf-86a5-4c5d-a7f8-0186dbc623b5",
                 "params": {
-                    "slaTime": "{%if vars.input.records[0].incRemainingAckSLA %}{{vars.input.records[0].incRemainingAckSLA}}{%else%}{{vars.sla_time_list.incAckTime}}{%endif%}",
+                    "slaTime": "{%if vars.input.records[0].incRemainingRespSLA %}{{vars.input.records[0].incRemainingRespSLA}}{%else%}{{vars.sla_time_list.incResTime}}{%endif%}",
                     "recordCreateTime": "{{vars.input.records[0].modifyDate}}"
                 },
                 "version": "2.0.0",


### PR DESCRIPTION
BugFix-0851660: On changing the Status of the Incident to "In Progress", the "Response SLA" timer values get set to Ack remaining time.
RCA: In "Incident - [03] Capture Response SLA (Upon Update)" playbook modified "Recalculate Response SLA" step "Duration in Minutes:*" value modified to Ack remaining time 
Fixed: Updated the jinja of "Duration in Minutes:*" field

UTC:
1. Create Incident with Severity Critical
2. Time Remain To Ack set for 10 mins
3. Time Remaining To Response set for 20 mins 
4. Change the Incident Status to In Progress after 2 mins
5. Time Remaining To Response working as expected 