### PR TITLE
BugFix 0852513

### DIFF
--- a/playbooks/03 - Enrich/Enrich Indicators (Type All).json
+++ b/playbooks/03 - Enrich/Enrich Indicators (Type All).json
@@ -285,7 +285,7 @@
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
-                    "reputation": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                    "reputation": "\/api\/3\/picklists\/9a611980-1b5e-4ae9-8062-eb2c0c433cff",
                     "enrichmentStatus": "\/api\/3\/picklists\/c6e46fde-97a2-48cc-8019-938c9c5aebd0"
                 },
                 "operation": "Append",


### PR DESCRIPTION
BugFix 0852513: Set Indicator Reputation to "No Reputation Available" if Integration is not available

UTC:
1. Install FortiSOAR 7.3.0 with SOAR Framework v2.0.1
2. Don't configure the any Threat Intel Integration for Indicator Enrichment
3. Create Alert type Phishing
4. Extract Indicator playbook will extract the indicators and wait for the enrichment
5. Enrich Indicators (Type All) playbook searches the pluggable enrichment playbooks for enrichment
6. No integrations are configure hence Enrich Indicators (Type All)  sets the reputation of the extracted indicators to "No Reputation Available" with enrichment status "Completed"
7.  Extract Indicator playbook will resume its execution without waiting for default time limit 2 mins