### PR TITLE
Update navigation.json - Updated user community link 

### DIFF
--- a/views/navigation.json
+++ b/views/navigation.json
@@ -338,7 +338,7 @@
                     }
                 },
                 "openInNewTab": true,
-                "url": "https:\/\/fusecommunity.fortinet.com\/groups\/community-home?CommunityKey=9f1420e8-e3c6-4535-8cae-3fa714da66d8",
+                "url": "https:\/\/community.fortinet.com\/t5\/FortiSOAR\/gh-p\/fortisoar",
                 "icon": "icon icon-users",
                 "editMode": false
             }


### PR DESCRIPTION
Fix: Update navigation.json - Updated user community link 
old link: https://fusecommunity.fortinet.com/groups/community-home?CommunityKey=9f1420e8-e3c6-4535-8cae-3fa714da66d8
new link: https://community.fortinet.com/t5/FortiSOAR/gh-p/fortisoar

UTC: 
1. New community link getting opened correctly
2. Exported the navigation panel json and imported to another instance and verified that new URL is reflected correctly