### PR TITLE
BugFixes and Doc Update

### DIFF
--- a/docs/extending-default-indicator-enrichment-process.md
+++ b/docs/extending-default-indicator-enrichment-process.md
@@ -41,3 +41,21 @@ This enrichment process is triggered when an indicator is created. On creation, 
     - Source data
     - Field mapping
     - Enrichment summary
+
+Refer to the below connector list for which pluggable enrichment is available:
+
+    | Connector                               |
+    |:----------------------------------------|
+    | APIVoid                                 |
+    | Active Directory                        |
+    | Anomali ThreatStream                    |
+    | Fortinet FortiGuard Threat Intelligence |
+    | Fortinet FortiSandbox                   |
+    | Fortinet Web Filter Lookup              |
+    | IBM XForce                              | 
+    | IP Quality Score                        | 
+    | IP Stack                                | 
+    | Symantec DeepSight Intelligence         | 
+    | URLScan.io                              | 
+    | VirusTotal                              | 
+    | Whois RDAP                              |  

--- a/info.json
+++ b/info.json
@@ -8,7 +8,7 @@
     "prerequisite": null,
     "publisher": "Fortinet",
     "certified": "true",
-    "description": "<p>The SOAR Framework Solution Pack helps users experience the power of FortiSOAR incident response.</p>",
+    "description": "The SOAR Framework Solution Pack helps users experience the power of FortiSOAR incident response.",
     "help": "https://github.com/fortinet-fortisoar/solution-pack-soar-framework/blob/release/2.1.1/README.md",
     "category": [],
     "supportInfo": "Fortinet Customer Support",

--- a/modules/alerts/mmd.json
+++ b/modules/alerts/mmd.json
@@ -55,7 +55,7 @@
             },
             "dataSourceFilters": null,
             "defaultValue": null,
-            "tooltip": null,
+            "tooltip": "List of IP Addresses in JSON format",
             "visibility": [
                 {
                     "sort": [],
@@ -119,7 +119,7 @@
             },
             "dataSourceFilters": null,
             "defaultValue": null,
-            "tooltip": null,
+            "tooltip": "List of File Hashes in JSON format",
             "visibility": [
                 {
                     "sort": [],

--- a/modules/alerts/mmd.json
+++ b/modules/alerts/mmd.json
@@ -55,7 +55,7 @@
             },
             "dataSourceFilters": null,
             "defaultValue": null,
-            "tooltip": "List of IP Addresses in JSON format",
+            "tooltip": "List of IP Addresses in JSON format\nfor e.g. [\"10.132.245.1\", \"10.132.245.2\"]",
             "visibility": [
                 {
                     "sort": [],
@@ -119,7 +119,7 @@
             },
             "dataSourceFilters": null,
             "defaultValue": null,
-            "tooltip": "List of File Hashes in JSON format",
+            "tooltip": "List of File Hashes in JSON format\nFor e.g. [\"c0202cf6aeab8437c638533d14563d35\", \"3de1609064a5b078a3b0b1cb4cdd4565\"]",
             "visibility": [
                 {
                     "sort": [],

--- a/picklists/Enrichment Status.json
+++ b/picklists/Enrichment Status.json
@@ -34,6 +34,16 @@
             "icon": null,
             "listName": "\/api\/3\/picklist_names\/feab2306-19d7-4e1c-b5f7-0a36ec6f95ed",
             "uuid": "c6e46fde-97a2-48cc-8019-938c9c5aebd0"
+        },
+        {
+            "@id": "\/api\/3\/picklists\/10106add-87ad-467f-8731-1a79d96f8dbd",
+            "@type": "Picklist",
+            "itemValue": "Failed",
+            "orderIndex": 3,
+            "color": null,
+            "icon": null,
+            "listName": "\/api\/3\/picklist_names\/feab2306-19d7-4e1c-b5f7-0a36ec6f95ed",
+            "uuid": "10106add-87ad-467f-8731-1a79d96f8dbd"
         }
     ],
     "uuid": "feab2306-19d7-4e1c-b5f7-0a36ec6f95ed"

--- a/playbooks/06 - IRP - War Room/Generate War Room Report.json
+++ b/playbooks/06 - IRP - War Room/Generate War Room Report.json
@@ -175,6 +175,7 @@
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [
-        "system"
+        "system",
+        "SystemWaitForCompletion"
     ]
 }

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,108 +4,19 @@
 
 ## Playbook Enhancements
 
-- New playbook `Fetch and Link Team to Related Records` has been added under the collection `08 - Utilities` 
-    - When triggered, this playbook fetches a team of the selected record and links it to all related records
-        > **For Example**: Teams `TeamA` and `TeamB` are assigned to `Alert-1` which further links to five indicators. Upon running this playbook, it also links teams `TeamA` and `TeamB` to the five associated indicators.
-
-- Modified `Extract Indicator` playbook under the collection `03 - Enrich`
-    - `First Seen` and `Last Seen` date fields are now present in the newly created indicator
-    - Indicators are now created from newly added `IP Addresses` and `File Hashes` fields in the **Alert** module
-    - In case of multi-tenancy, a tenant from the alert record is also assigned to the indicator
-    - Email indicators that are part of the exclude domain indicators list (`Excludelist_Domains` global variable) are now ignored
-
-- Modified `Create Communication Record (Alert)` playbook under the collection `06 - IRP - Communications Tracking`
-    - User can now select email templates while sending an email from **Alert** detail view
-
-- Modified `Alert - Escalate To Incident` playbook under the collection `06 - IRP - Case Management 
-    - In case of multi-tenancy, this playbook assigns escalated alert tenant value to a newly created Incident record 
-
-- Renamed `Delete Enrichment Global Variables` playbook to `Reset Enrichment Global Variables` under the collection `03 - Enrich`
-
-- Deactivated the following playbooks:
-    - `Assign Random User to Unassigned Alerts` and `Assign Random User to Unassigned Incidents` playbooks under the collection `06 - IRP - Case Management`
-    - `Prioritize Alerts With VIP Assets` under collection `03 - Triage`   
-    >**NOTE** Users need to activate this playbook if they want to create the asset record for the hostname mentioned in the alert's `Target Asset` field
+- Modified `Generate War Room Report` playbook under the collection `06 - IRP - War Room`
+    - The loading icon will now visible for the `Generate Report` button till the report is generated for the war room record
 
 ## Module Enhancements
 
-- **Queue Management Module**
-    - By default, the **Default** queue record now is `Inactive`
-
-        >**NOTE**: In every SOAR Framework solution pack upgrade, the **Default** queue record is marked `Inactive`. To use the **Default** queue, you need to activate it.
-    
-- **Tasks Module**
-    - `Re-Opened` dropdown item is removed from the *Status* drop-down
-
 - **Asset Module**
-    - A new *Asset Risk* drop-down was added with the options `Minimal`, `Low`, `Medium`, `High`, and `Critical`
-    
-- **Event Module**
-    - Updated System View Template (SVT) as per the module's best practices
+    - Added new `Source Data` field
+    - Renamed `Related Record` tab to `Correlations` in Asset detailed view
 
 - **Alert Module**
-    - Added new `Resolved Automatedly` hidden boolean field
-    - Added new `Recommendation setting` for Playbook suggestion based on Name and Type of **Alerts**
-    - Added new `IP Addresses` and `File Hashes` fields
-
-        >**NOTE** `Indicator_Type_Map` global variable is also updated with the `IP Addresses` and `File Hashes` fields. These fields are now also used during indicator extraction
-
-- **Incident Module**
-    - Added new `Recommendation Setting` for playbook suggestion based on Name and Type of **Incidents**
-
-- Added new `Key Store` module. You can find it under the `Resources` navigation panel
-
-
-## Rules Enhancements
-
-- `In-App Notifications` have been disabled for following `Rules`
-
-    - Alert - Notify Creation
-    - Alert - Notify Updates 
-    - Incident - Notify Creation 
-    - Incident - Notify Updates
-
-## Introduced Reference Block(s) 
-
-- Introduced following Out of the box reference blocks:
-    - Approval-Based Decision 
-    - Bulk ingest records using the 'Ingest Bulk Feed' Step
-    - Check if an IP address is Internal or External
-    - Condition-based Post-Create Trigger 
-    - Condition-based Post-Update Trigger
-    - Create and Link Asset to Alert
-    - Execute Playbook Step using Do-Until Loop
-    - Execute Playbook Step using Parallel Looping
-    - Execute Playbook step using Sequential Looping
-    - Execute Playbook using Mock Data
-    - Extracting Artifacts from a String 
-    - Fetch Emails From Particular Inbox in Exchange
-    - Handling Record Uniqueness (No Change Needed To Existing Record)
-    - Handling Record Uniqueness (Stop Process when Duplicate Record Found)
-    - Handling Record Uniqueness (Update Existing Record - All Fields)
-    - Handling Record Uniqueness (Update Existing Record - Only Selected Fields)
-    - Make a REST API Call
-    - Manual Trigger using User Input Prompt
-    - Manual Trigger with Visibility Condition
-    - Manual Trigger without Selecting Records
-    - Posting a Message on Triggering Record (using Create Record Step)
-    - Posting a Message on Triggering Record (using Step Utilities)
-    - Set New Variable to Store Record Information 
-    - Using Code Snippet
-    - Using Custom API Endpoint Trigger
-    - Using Decision Step
-    - Using Ignore Error to Avoid Playbook Failure
-    - Using Manual Input Step
-    - Using Manual Task Step
-    - Calculate Severity using ResolveRange
+    - Added the `Event` module in the `Correlations` tab of the Alert detailed view
+    - Added the tooltips for fields `IP Addresses` and `File Hashes`
 
 ## Resolved Issues
 
-- Asset records with empty hostnames were being created by the `Prioritize Alerts With VIP Assets` playbook under the collection `03 - Triage`. Now, the hostname input value is correctly passed so asset records have correct hostnames
-
-- Updated the FortiSOAR Community page URL to fix the Page not found error while accessing FortiSOAR Community Page from `Navigation Panel > User Community`.
-
-- When an appropriate Threat Intel connector is not present, the `Indicator (Manual Trigger) - Get Latest Reputation` playbook under the collection `03 - Enrich` updates the indicator reputation to `No Reputation Available` instead of `blank`
-
-- Fixed `Relationship widget` configuration in *Alert*, *Incidents*, and *Warroom* detailed view to show modules that are part of the included list of the widget configuration
-
+- Fixed the `Fetch and Link Team to Related Records` playbook under `08 Utilities` collection which was failing when "IP Addresses" and "File Hashes" fields are populated in the alert record 

--- a/release_notes.md
+++ b/release_notes.md
@@ -17,6 +17,9 @@
     - Added the `Event` module in the `Correlations` tab of the Alert detailed view
     - Added the tooltips for fields `IP Addresses` and `File Hashes`
 
+- **Indicator Module*
+    - A new `Failed` picklist item is added to the *Enrichment Status* picklist
+
 ## Resolved Issues
 
 - Fixed the `Fetch and Link Team to Related Records` playbook under `08 Utilities` collection which was failing when "IP Addresses" and "File Hashes" fields are populated in the alert record 


### PR DESCRIPTION
> Mantis#0900213 - Add a tooltip for the "Filehashes" and "IP Addresses" field
- Validated that the tooltip is added to the alert fields "IP Addresses" and "File Hashes"

> Mantis#0815265 - WarRoom - Generate Report button should have a loading icon visible till the report is generated
- Validated that the loading icon is visible for the `Generate Report` button till the report is generated for the war room record

> Mantis#0874338 - On Light theme, SP description is not readable
- Validated that in light theme, the description of the solution pack is displayed clearly when hovering on the solution pack card in the content hub

> Mantis#0905283 - Add a new picklist item "Failed" in the erichmentStatus picklist to show failure
- Validated that the item "Failed" has been added to the "Enrichment Status" picklist