### PR TITLE
Enhancements

### DIFF
--- a/connectors/data.json
+++ b/connectors/data.json
@@ -66,6 +66,20 @@
         "install_mode": "rpm"
     },
     {
+        "name": "file-content-extraction",
+        "label": "File Content Extraction",
+        "category": "utilities",
+        "description": "Utility to Extract Text, Artifacts and Metadata from almost any file. Internet connectivity is required for the connector to download dependent packages",
+        "publisher": null,
+        "version": "1.0.3",
+        "operation_roles": [],
+        "configurations": [],
+        "dataImports": [],
+        "install_mode": "rpm",
+        "rpm_name": "cyops-connector-file-content-extraction-1.0.3",
+        "installer_path": "cyops-connector-file-content-extraction-1.0.3"
+    },
+    {
         "name": "fortigate-firewall",
         "label": "Fortinet FortiGate",
         "category": "Firewall and Network Protection",

--- a/info.json
+++ b/info.json
@@ -626,6 +626,10 @@
                 "apiName": "exchange"
             },
             {
+                "name": "File Content Extraction",
+                "apiName": "file-content-extraction"
+            },
+            {
                 "name": "Fortinet FortiClient EMS",
                 "apiName": "fortinet-forticlient-ems"
             },

--- a/playbooks/03 - Enrich/Extract Indicators from Attachments.json
+++ b/playbooks/03 - Enrich/Extract Indicators from Attachments.json
@@ -1,0 +1,437 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Extract Indicators from Attachments",
+    "aliasName": null,
+    "tag": null,
+    "description": "Enriches Attachment with extracted text, indicators and Meta data",
+    "isActive": true,
+    "debug": true,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [
+        "Alert ID",
+        "excluded_iocs"
+    ],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/deaa4d19-7444-4f3a-a80e-9577436f25ef",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/e7f619d4-4ab0-4346-b128-16eed7861ca1",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "unified_iocs": "[]",
+                "extracted_text": "[]",
+                "file_names_to_extract": "[]"
+            },
+            "status": null,
+            "top": "165",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "417c69d3-6139-4c44-be56-f5d2ffbc3c43"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Exit",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.2.3",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "c48b363d-9bb6-4845-9603-29926459e697"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Extract Indicators",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "data": "{{vars.item.data['extracted_text']}}",
+                    "whitelist": "{{vars.input.params['excluded_iocs']}}",
+                    "case_sensitive": false,
+                    "override_regex": false,
+                    "private_whitelist": true
+                },
+                "version": "3.2.3",
+                "for_each": {
+                    "item": "{{vars.extracted_text}}",
+                    "parallel": false,
+                    "condition": ""
+                },
+                "connector": "cyops_utilities",
+                "operation": "extract_artifacts",
+                "operationTitle": "FSR: Extract Artifacts from String",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1245",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "b82e7069-76f8-45cd-af8c-0a815b21c37b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Extract Text for Attachment",
+            "description": null,
+            "arguments": {
+                "name": "File Content Extraction",
+                "config": "70616ece-f92a-459b-88e5-cbf1b07b37b2",
+                "params": {
+                    "file_iri": "{{vars.item.file['@id']}}",
+                    "html_output_format": true
+                },
+                "version": "1.0.3",
+                "for_each": {
+                    "item": "{{vars.steps.Find_Related_Attachments}}",
+                    "parallel": false,
+                    "condition": "{{vars.item.file.filename.split('.')[-1] not in ['zip']}}"
+                },
+                "connector": "file-content-extraction",
+                "operation": "extract_text",
+                "operationTitle": "Extract Text",
+                "pickFromTenant": false,
+                "step_variables": {
+                    "__extracted_text": "{{vars.extracted_text.extend(vars.result)}}"
+                }
+            },
+            "status": null,
+            "top": "570",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "c039b9c1-a1e9-4d7a-8450-fdda9b568c4f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Extract Text for Zip File",
+            "description": null,
+            "arguments": {
+                "name": "File Content Extraction",
+                "config": "70616ece-f92a-459b-88e5-cbf1b07b37b2",
+                "params": {
+                    "file_iri": "{{vars.item.data['@id']}}",
+                    "html_output_format": true
+                },
+                "version": "1.0.3",
+                "for_each": {
+                    "item": "{{vars.steps.Upload_Extracted_Files_to_FSR}}",
+                    "parallel": false,
+                    "condition": ""
+                },
+                "connector": "file-content-extraction",
+                "operation": "extract_text",
+                "operationTitle": "Extract Text",
+                "pickFromTenant": false,
+                "step_variables": {
+                    "__extracted_text": "{{vars.extracted_text.extend(vars.result)}}"
+                }
+            },
+            "status": null,
+            "top": "1110",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "2707b519-7d26-4e58-a362-69a2adb7528a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Related Attachments",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "alerts.id",
+                            "value": "{{vars.input.params['Alert ID']}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ]
+                },
+                "module": "attachments?$limit=999&$relationships=true&$fsr_max_relation_count=100",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "e09b9459-fdc2-4122-b88a-b5d796b6a733"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Attachment Found",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "No",
+                        "step_iri": "\/api\/3\/workflow_steps\/c48b363d-9bb6-4845-9603-29926459e697",
+                        "condition": "{{ vars.steps.Find_Related_Attachments | length == 0 }}",
+                        "step_name": "Exit"
+                    },
+                    {
+                        "option": "Yes",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/c039b9c1-a1e9-4d7a-8450-fdda9b568c4f",
+                        "step_name": "Extract text"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "435",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "8f60e32e-f350-40c0-b4d4-994aeffd7f00"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Files to Extract",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Unzip_Zip_Files}}",
+                    "parallel": false,
+                    "condition": ""
+                },
+                "__set_file_for_etraction": "{{vars.file_names_to_extract.extend(vars.item.data.filenames)}}"
+            },
+            "status": null,
+            "top": "840",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "261c9c56-6114-4a92-a675-494febb411ec"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Result",
+            "description": null,
+            "arguments": {
+                "attachment_indicators": "{{vars.steps.Extract_Indicators | json_query(\"[0].data.results\") | flatten(levels=1)}}"
+            },
+            "status": null,
+            "top": "1380",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "3e6f197c-a4b8-4f2f-8ee1-54d63d60b3ea"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "step_variables": {
+                    "input": {
+                        "params": []
+                    }
+                }
+            },
+            "status": null,
+            "top": "30",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+            "group": null,
+            "uuid": "e7f619d4-4ab0-4346-b128-16eed7861ca1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Unzip Zip Files",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "type": "File IRI",
+                    "file_iri": "{{vars.item.file['@id']}}",
+                    "password": ""
+                },
+                "version": "3.2.3",
+                "for_each": {
+                    "item": "{{vars.steps.Find_Related_Attachments}}",
+                    "parallel": false,
+                    "condition": "{{vars.item.file.filename.split('.')[-1] == 'zip'}}"
+                },
+                "connector": "cyops_utilities",
+                "operation": "unzip_protected_file",
+                "operationTitle": "File: Unzip",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "58d6e0d9-7635-4813-899f-e9e4de7c6f0b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Upload Extracted Files to FSR",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "filename": "{{vars.item | regex_replace(\"[^A-Za-z0-9.\\-]\", \"\"\"\")}}",
+                    "file_path": "{{vars.item}}",
+                    "create_attachment": false
+                },
+                "version": "3.2.3",
+                "for_each": {
+                    "item": "{{vars.file_names_to_extract}}",
+                    "parallel": false,
+                    "condition": ""
+                },
+                "connector": "cyops_utilities",
+                "operation": "upload_file_to_cyops",
+                "operationTitle": "File: Upload a file in the system and Create an Attachment",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "941469e1-ba89-4770-9d7d-4c42e1491c75"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Find Related Attachments",
+            "targetStep": "\/api\/3\/workflow_steps\/e09b9459-fdc2-4122-b88a-b5d796b6a733",
+            "sourceStep": "\/api\/3\/workflow_steps\/417c69d3-6139-4c44-be56-f5d2ffbc3c43",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "143b14c7-e56f-417a-ac4d-47404b173ed2"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Extract Indicators -> Format Extracted Data",
+            "targetStep": "\/api\/3\/workflow_steps\/3e6f197c-a4b8-4f2f-8ee1-54d63d60b3ea",
+            "sourceStep": "\/api\/3\/workflow_steps\/b82e7069-76f8-45cd-af8c-0a815b21c37b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "adab2fa0-ffdb-4a95-9d9e-0d1a138b7484"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Extract Text for Zip File -> Extract Indicators",
+            "targetStep": "\/api\/3\/workflow_steps\/b82e7069-76f8-45cd-af8c-0a815b21c37b",
+            "sourceStep": "\/api\/3\/workflow_steps\/2707b519-7d26-4e58-a362-69a2adb7528a",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "a5fb51b9-4103-4953-a3c7-e91ca9aecb66"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Extract text -> Unzip Zip files",
+            "targetStep": "\/api\/3\/workflow_steps\/58d6e0d9-7635-4813-899f-e9e4de7c6f0b",
+            "sourceStep": "\/api\/3\/workflow_steps\/c039b9c1-a1e9-4d7a-8450-fdda9b568c4f",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "4a6d227f-008c-4cf5-b780-97a123afb5ac"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Related Attachments -> Is Attachment Found",
+            "targetStep": "\/api\/3\/workflow_steps\/8f60e32e-f350-40c0-b4d4-994aeffd7f00",
+            "sourceStep": "\/api\/3\/workflow_steps\/e09b9459-fdc2-4122-b88a-b5d796b6a733",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "4473cb84-8911-4c93-9a2b-aaacdfb08fd8"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Attachment Found -> Exit",
+            "targetStep": "\/api\/3\/workflow_steps\/c48b363d-9bb6-4845-9603-29926459e697",
+            "sourceStep": "\/api\/3\/workflow_steps\/8f60e32e-f350-40c0-b4d4-994aeffd7f00",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "740fff38-fb22-477e-8175-e08afb4ffa8a"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Attachment Found -> Extract text",
+            "targetStep": "\/api\/3\/workflow_steps\/c039b9c1-a1e9-4d7a-8450-fdda9b568c4f",
+            "sourceStep": "\/api\/3\/workflow_steps\/8f60e32e-f350-40c0-b4d4-994aeffd7f00",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "3f0f660f-8190-4ba5-b8dd-4a78a861d895"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Set files to extract -> Upload extracted files",
+            "targetStep": "\/api\/3\/workflow_steps\/941469e1-ba89-4770-9d7d-4c42e1491c75",
+            "sourceStep": "\/api\/3\/workflow_steps\/261c9c56-6114-4a92-a675-494febb411ec",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e771caf0-e9a2-4ed7-a959-1cebd0316e93"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/417c69d3-6139-4c44-be56-f5d2ffbc3c43",
+            "sourceStep": "\/api\/3\/workflow_steps\/e7f619d4-4ab0-4346-b128-16eed7861ca1",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e9dd601d-d71c-4d63-b143-785307262b64"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Unzip Zip files -> Set files to extract",
+            "targetStep": "\/api\/3\/workflow_steps\/261c9c56-6114-4a92-a675-494febb411ec",
+            "sourceStep": "\/api\/3\/workflow_steps\/58d6e0d9-7635-4813-899f-e9e4de7c6f0b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "084912e4-8308-4b83-9859-212473baf45f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Upload extracted files -> Copy of Extract text",
+            "targetStep": "\/api\/3\/workflow_steps\/2707b519-7d26-4e58-a362-69a2adb7528a",
+            "sourceStep": "\/api\/3\/workflow_steps\/941469e1-ba89-4770-9d7d-4c42e1491c75",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ccce5b77-91fb-4fdc-814d-73ce1635b2cb"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "uuid": "b7cd4c27-6298-4093-9689-dfc7b26d0e7e",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "Referenced",
+        "Advisory",
+        "File-Content-Extraction"
+    ]
+}

--- a/playbooks/03 - Enrich/Extract Indicators.json
+++ b/playbooks/03 - Enrich/Extract Indicators.json
@@ -22,11 +22,11 @@
             "name": "Removing NULL Indicators",
             "description": "Removing null indicators extracted from email",
             "arguments": {
-                "unified_iocs": "{{ vars.unified_iocs | json_query('[?value != null]') }}"
+                "unified_iocs": "{{ vars.unified_iocs | json_query('[?value != null]') | unique}}"
             },
             "status": null,
-            "top": "1245",
-            "left": "310",
+            "top": "1380",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "0311b9ca-831e-45df-ae02-e522633881cf"
@@ -52,8 +52,8 @@
                 ]
             },
             "status": null,
-            "top": "1515",
-            "left": "310",
+            "top": "1650",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "036dfd34-7505-4d8f-9b5d-49f5d130062b"
@@ -83,7 +83,7 @@
             },
             "status": null,
             "top": "975",
-            "left": "310",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
             "uuid": "18f57e7b-c825-430a-9b86-fb1c8274b257"
@@ -116,8 +116,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1800",
-            "left": "120",
+            "top": "1860",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "1c47615b-90b3-439d-9d45-eb29b14064ed"
@@ -137,7 +137,7 @@
             },
             "status": null,
             "top": "300",
-            "left": "310",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "21ffcc50-7679-4df9-bacb-ad7480c465cd"
@@ -167,7 +167,7 @@
             },
             "status": null,
             "top": "840",
-            "left": "310",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
             "uuid": "6ea0365a-3a12-495c-82d9-17c787bda75f"
@@ -177,11 +177,11 @@
             "name": "Unified Email IOCs",
             "description": null,
             "arguments": {
-                "_dummy": "{%if vars.email_body_iocs %} \n{%for item in vars.email_body_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%if vars.header_iocs%}\n{%for item in vars.header_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%if vars.description_iocs%}\n{%for item in vars.description_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%if vars.file_hash_iocs %}\n{%for item in vars.file_hash_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}\n{%endif%}\n\n{%for item in vars.alert_field_iocs%}\n{{vars.unified_iocs.append(item)}}\n{%endfor%}"
+                "_dummy": "{%if vars.email_body_iocs %}{{vars.unified_iocs.extend(vars.email_body_iocs)}}{%endif%}\n\n{%if vars.header_iocs%}\n{{vars.unified_iocs.extend(vars.header_iocs)}}\n{%endif%}\n\n{%if vars.description_iocs%}{{vars.unified_iocs.extend(vars.description_iocs)}}{%endif%}\n\n{%if vars.file_hash_iocs %}{{vars.unified_iocs.extend(vars.file_hash_iocs)}}{%endif%}\n\n{% if vars.alert_field_iocs %}{{vars.unified_iocs.append(vars.alert_field_iocs)}}{% endif %}\n\n{% if vars.email_attachment_iocs %}{{vars.unified_iocs.extend(vars.email_attachment_iocs)}}{% endif %}"
             },
             "status": null,
-            "top": "1110",
-            "left": "310",
+            "top": "1245",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "79976d9e-2f2b-43c1-87a1-76db28946e0e"
@@ -200,7 +200,7 @@
             },
             "status": null,
             "top": "300",
-            "left": "660",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "915e6a13-58cc-435f-9b7e-ed6250393195"
@@ -252,7 +252,6 @@
                                 "value": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
                                 "_value": {
                                     "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
-                                    "display": "TBD",
                                     "itemValue": "TBD"
                                 },
                                 "operator": "neq"
@@ -281,8 +280,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1660",
-            "left": "520",
+            "top": "1720",
+            "left": "445",
             "stepType": "\/api\/3\/workflow_step_types\/6832e556-b9c7-497a-babe-feda3bd27dbf",
             "group": null,
             "uuid": "925de451-5069-41a6-9a5b-ec1a9b071d71"
@@ -312,7 +311,7 @@
             },
             "status": null,
             "top": "705",
-            "left": "310",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
             "uuid": "9394cafa-441a-4131-b328-bbd2e3339c12"
@@ -326,7 +325,7 @@
             },
             "status": null,
             "top": "435",
-            "left": "310",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "b31ff3b1-db1b-4b2d-b170-ebe51e2a63c7"
@@ -371,7 +370,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "485",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/ea155646-3821-4542-9702-b246da430a8d",
             "group": null,
             "uuid": "c5791d4a-fa1c-41d2-8175-b459c32620e9"
@@ -398,7 +397,7 @@
             },
             "status": null,
             "top": "165",
-            "left": "485",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "c639685a-e65e-4be4-8fcf-e57613edb51b"
@@ -426,8 +425,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1800",
-            "left": "520",
+            "top": "1860",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "cd14393f-d928-4a4f-ba16-c10d67d53af6"
@@ -441,7 +440,7 @@
             },
             "status": null,
             "top": "570",
-            "left": "310",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "e7bbfc81-c4c6-4768-a875-e24d81d30de5"
@@ -490,23 +489,39 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
-            "left": "310",
+            "top": "1515",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "f815b438-2e48-40c2-83c1-003b32f19760"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Extract Attachment Indicators",
+            "description": null,
+            "arguments": {
+                "when": "{{vars.input.records[0].type.itemValue in ['Suspicious Email', 'Phishing']}}",
+                "arguments": {
+                    "Alert ID": "{{vars.input.records[0].id}}",
+                    "excluded_iocs": "{{vars.excluded_indicators}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "email_attachment_iocs": "{{vars.steps.Extract_Attachment_Indicators[\"attachment_indicators\"]}}"
+                },
+                "pass_parent_env": false,
+                "pass_input_record": false,
+                "workflowReference": "\/api\/3\/workflows\/b7cd4c27-6298-4093-9689-dfc7b26d0e7e"
+            },
+            "status": null,
+            "top": "1110",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "a5b6f558-5b1a-4953-9c97-d83fd818bc3a"
         }
     ],
     "routes": [
-        {
-            "@type": "WorkflowRoute",
-            "name": "Wait For Enrichment -> Add Comment",
-            "targetStep": "\/api\/3\/workflow_steps\/cd14393f-d928-4a4f-ba16-c10d67d53af6",
-            "sourceStep": "\/api\/3\/workflow_steps\/925de451-5069-41a6-9a5b-ec1a9b071d71",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "9c51c550-6519-4aaa-88a1-313e3e460e8b"
-        },
         {
             "@type": "WorkflowRoute",
             "name": "Add Comment for Not Enrich Indicators -> Update Alert State",
@@ -514,106 +529,8 @@
             "sourceStep": "\/api\/3\/workflow_steps\/cd14393f-d928-4a4f-ba16-c10d67d53af6",
             "label": null,
             "isExecuted": false,
+            "group": null,
             "uuid": "0f9ca6c6-2f87-4ed9-9fa8-156fa5d76564"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Wait For Enrichment -> Update Alert State",
-            "targetStep": "\/api\/3\/workflow_steps\/1c47615b-90b3-439d-9d45-eb29b14064ed",
-            "sourceStep": "\/api\/3\/workflow_steps\/925de451-5069-41a6-9a5b-ec1a9b071d71",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "26271bea-685b-4532-acf1-e12ee0c2fe6c"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Extract Indicators from header -> Extract Indicators from body",
-            "targetStep": "\/api\/3\/workflow_steps\/6ea0365a-3a12-495c-82d9-17c787bda75f",
-            "sourceStep": "\/api\/3\/workflow_steps\/9394cafa-441a-4131-b328-bbd2e3339c12",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "2c439392-cf08-4dc5-99ce-435b6217072f"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Unified Email IOCs -> Removing NULL Indicators",
-            "targetStep": "\/api\/3\/workflow_steps\/0311b9ca-831e-45df-ae02-e522633881cf",
-            "sourceStep": "\/api\/3\/workflow_steps\/79976d9e-2f2b-43c1-87a1-76db28946e0e",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "02b5aefa-5a48-4f99-9c98-b34d19c1f759"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Start -> Is the record for a dedicated tenant",
-            "targetStep": "\/api\/3\/workflow_steps\/c639685a-e65e-4be4-8fcf-e57613edb51b",
-            "sourceStep": "\/api\/3\/workflow_steps\/c5791d4a-fa1c-41d2-8175-b459c32620e9",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "bf45ba17-fd3d-45eb-8fa9-565b725d7a09"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Extract Indicators from body -> Extract Indicators from description",
-            "targetStep": "\/api\/3\/workflow_steps\/18f57e7b-c825-430a-9b86-fb1c8274b257",
-            "sourceStep": "\/api\/3\/workflow_steps\/6ea0365a-3a12-495c-82d9-17c787bda75f",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "7ca27a6c-1092-466d-ade0-2f173827d0e6"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Extract Indicators from description -> Unified Email IOCs",
-            "targetStep": "\/api\/3\/workflow_steps\/79976d9e-2f2b-43c1-87a1-76db28946e0e",
-            "sourceStep": "\/api\/3\/workflow_steps\/18f57e7b-c825-430a-9b86-fb1c8274b257",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "0b371874-a32d-4043-903b-cbff4d35b11b"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is the record for a dedicated tenant -> Exit",
-            "targetStep": "\/api\/3\/workflow_steps\/915e6a13-58cc-435f-9b7e-ed6250393195",
-            "sourceStep": "\/api\/3\/workflow_steps\/c639685a-e65e-4be4-8fcf-e57613edb51b",
-            "label": "Yes, Extract at Tenant Node",
-            "isExecuted": false,
-            "uuid": "eda46593-c13f-4468-82f2-8bfa966a53d9"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is the record for a dedicated tenant -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/21ffcc50-7679-4df9-bacb-ad7480c465cd",
-            "sourceStep": "\/api\/3\/workflow_steps\/c639685a-e65e-4be4-8fcf-e57613edb51b",
-            "label": "No, Extract Here",
-            "isExecuted": false,
-            "uuid": "298d26b7-1dc1-4ae1-b224-570f4e8c70c9"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Removing NULL Indicators -> Create Indicator",
-            "targetStep": "\/api\/3\/workflow_steps\/f815b438-2e48-40c2-83c1-003b32f19760",
-            "sourceStep": "\/api\/3\/workflow_steps\/0311b9ca-831e-45df-ae02-e522633881cf",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "e5a39895-b4a1-4e2e-b761-097e6576a66b"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Create Indicator -> Are New Indicators Created",
-            "targetStep": "\/api\/3\/workflow_steps\/036dfd34-7505-4d8f-9b5d-49f5d130062b",
-            "sourceStep": "\/api\/3\/workflow_steps\/f815b438-2e48-40c2-83c1-003b32f19760",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "6f5a17ce-67ca-4f8a-8f56-69b75fb317d2"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Are New Indicators Created -> Wait For Enrichment",
-            "targetStep": "\/api\/3\/workflow_steps\/925de451-5069-41a6-9a5b-ec1a9b071d71",
-            "sourceStep": "\/api\/3\/workflow_steps\/036dfd34-7505-4d8f-9b5d-49f5d130062b",
-            "label": "Yes",
-            "isExecuted": false,
-            "uuid": "c8af9b0e-deba-4597-bef1-dd67e015fd20"
         },
         {
             "@type": "WorkflowRoute",
@@ -622,25 +539,18 @@
             "sourceStep": "\/api\/3\/workflow_steps\/036dfd34-7505-4d8f-9b5d-49f5d130062b",
             "label": "No",
             "isExecuted": false,
+            "group": null,
             "uuid": "0c61b05d-00d1-4628-8962-6252414c9aaa"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Indicator List -> Get Indicators",
-            "targetStep": "\/api\/3\/workflow_steps\/e7bbfc81-c4c6-4768-a875-e24d81d30de5",
-            "sourceStep": "\/api\/3\/workflow_steps\/b31ff3b1-db1b-4b2d-b170-ebe51e2a63c7",
-            "label": null,
+            "name": "Are New Indicators Created -> Wait For Enrichment",
+            "targetStep": "\/api\/3\/workflow_steps\/925de451-5069-41a6-9a5b-ec1a9b071d71",
+            "sourceStep": "\/api\/3\/workflow_steps\/036dfd34-7505-4d8f-9b5d-49f5d130062b",
+            "label": "Yes",
             "isExecuted": false,
-            "uuid": "81002f94-f655-40c1-b589-676b16873ce5"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Get Indicators -> Extract Indicators from header",
-            "targetStep": "\/api\/3\/workflow_steps\/9394cafa-441a-4131-b328-bbd2e3339c12",
-            "sourceStep": "\/api\/3\/workflow_steps\/e7bbfc81-c4c6-4768-a875-e24d81d30de5",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "98e591b8-0886-42f2-92c9-afe5d08507ff"
+            "group": null,
+            "uuid": "c8af9b0e-deba-4597-bef1-dd67e015fd20"
         },
         {
             "@type": "WorkflowRoute",
@@ -649,7 +559,148 @@
             "sourceStep": "\/api\/3\/workflow_steps\/21ffcc50-7679-4df9-bacb-ad7480c465cd",
             "label": null,
             "isExecuted": false,
+            "group": null,
             "uuid": "60c84504-76fc-403a-8e29-d8866b13b809"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Create Indicator -> Are New Indicators Created",
+            "targetStep": "\/api\/3\/workflow_steps\/036dfd34-7505-4d8f-9b5d-49f5d130062b",
+            "sourceStep": "\/api\/3\/workflow_steps\/f815b438-2e48-40c2-83c1-003b32f19760",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "071f1000-9bd6-44fa-b1fc-7477aa84d72a"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Extract Attachment Indicators -> Unified Email IOCs",
+            "targetStep": "\/api\/3\/workflow_steps\/79976d9e-2f2b-43c1-87a1-76db28946e0e",
+            "sourceStep": "\/api\/3\/workflow_steps\/a5b6f558-5b1a-4953-9c97-d83fd818bc3a",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "fbedec94-96b1-43f4-baa8-d9629e3caa1f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Extract Indicators from body -> Extract Indicators from description",
+            "targetStep": "\/api\/3\/workflow_steps\/18f57e7b-c825-430a-9b86-fb1c8274b257",
+            "sourceStep": "\/api\/3\/workflow_steps\/6ea0365a-3a12-495c-82d9-17c787bda75f",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "7ca27a6c-1092-466d-ade0-2f173827d0e6"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Extract Indicators from description -> Extract Attachment Indicators",
+            "targetStep": "\/api\/3\/workflow_steps\/a5b6f558-5b1a-4953-9c97-d83fd818bc3a",
+            "sourceStep": "\/api\/3\/workflow_steps\/18f57e7b-c825-430a-9b86-fb1c8274b257",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "c7f4ba7c-3c96-4979-8987-fc9e9c4b0bc4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Extract Indicators from header -> Extract Indicators from body",
+            "targetStep": "\/api\/3\/workflow_steps\/6ea0365a-3a12-495c-82d9-17c787bda75f",
+            "sourceStep": "\/api\/3\/workflow_steps\/9394cafa-441a-4131-b328-bbd2e3339c12",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "2c439392-cf08-4dc5-99ce-435b6217072f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Indicators -> Extract Indicators from header",
+            "targetStep": "\/api\/3\/workflow_steps\/9394cafa-441a-4131-b328-bbd2e3339c12",
+            "sourceStep": "\/api\/3\/workflow_steps\/e7bbfc81-c4c6-4768-a875-e24d81d30de5",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "98e591b8-0886-42f2-92c9-afe5d08507ff"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is the record for a dedicated tenant -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/21ffcc50-7679-4df9-bacb-ad7480c465cd",
+            "sourceStep": "\/api\/3\/workflow_steps\/c639685a-e65e-4be4-8fcf-e57613edb51b",
+            "label": "No, Extract Here",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "298d26b7-1dc1-4ae1-b224-570f4e8c70c9"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is the record for a dedicated tenant -> Exit",
+            "targetStep": "\/api\/3\/workflow_steps\/915e6a13-58cc-435f-9b7e-ed6250393195",
+            "sourceStep": "\/api\/3\/workflow_steps\/c639685a-e65e-4be4-8fcf-e57613edb51b",
+            "label": "Yes, Extract at Tenant Node",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "eda46593-c13f-4468-82f2-8bfa966a53d9"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Removing NULL Indicators -> Create Indicator",
+            "targetStep": "\/api\/3\/workflow_steps\/f815b438-2e48-40c2-83c1-003b32f19760",
+            "sourceStep": "\/api\/3\/workflow_steps\/0311b9ca-831e-45df-ae02-e522633881cf",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "a3da5427-0f0b-4453-868d-759f8bcf6cc2"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Is the record for a dedicated tenant",
+            "targetStep": "\/api\/3\/workflow_steps\/c639685a-e65e-4be4-8fcf-e57613edb51b",
+            "sourceStep": "\/api\/3\/workflow_steps\/c5791d4a-fa1c-41d2-8175-b459c32620e9",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "bf45ba17-fd3d-45eb-8fa9-565b725d7a09"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Unified Email IOCs -> Removing NULL Indicators",
+            "targetStep": "\/api\/3\/workflow_steps\/0311b9ca-831e-45df-ae02-e522633881cf",
+            "sourceStep": "\/api\/3\/workflow_steps\/79976d9e-2f2b-43c1-87a1-76db28946e0e",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "02b5aefa-5a48-4f99-9c98-b34d19c1f759"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Indicator List -> Get Indicators",
+            "targetStep": "\/api\/3\/workflow_steps\/e7bbfc81-c4c6-4768-a875-e24d81d30de5",
+            "sourceStep": "\/api\/3\/workflow_steps\/b31ff3b1-db1b-4b2d-b170-ebe51e2a63c7",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "81002f94-f655-40c1-b589-676b16873ce5"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Wait For Enrichment -> Add Comment",
+            "targetStep": "\/api\/3\/workflow_steps\/cd14393f-d928-4a4f-ba16-c10d67d53af6",
+            "sourceStep": "\/api\/3\/workflow_steps\/925de451-5069-41a6-9a5b-ec1a9b071d71",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9c51c550-6519-4aaa-88a1-313e3e460e8b"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Wait For Enrichment -> Update Alert State",
+            "targetStep": "\/api\/3\/workflow_steps\/1c47615b-90b3-439d-9d45-eb29b14064ed",
+            "sourceStep": "\/api\/3\/workflow_steps\/925de451-5069-41a6-9a5b-ec1a9b071d71",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "26271bea-685b-4532-acf1-e12ee0c2fe6c"
         }
     ],
     "groups": [],

--- a/playbooks/08 - Utilities/Convert FortiSOAR User to SAML - Collect User Email IDs.json
+++ b/playbooks/08 - Utilities/Convert FortiSOAR User to SAML - Collect User Email IDs.json
@@ -1,0 +1,149 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Convert FortiSOAR User to SAML - Collect User Email IDs",
+    "aliasName": null,
+    "tag": null,
+    "description": "Collects comma-separated Email-IDs of the existing FortiSOAR users that to be converted to SAML Users.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/20289298-cdd6-4052-8fa0-11e2603dca00",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/573c55f0-6c59-4957-bb55-83381f91d595",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "emails": "{{ vars.input.params.sAMLEmailIDs.split(',') }}",
+                "user_type": "6",
+                "fsr_hostname": "{{globalVars.Server_fqhn}}"
+            },
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "58c7c031-0e0c-4d18-b7bc-3e7c24d6084b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "route": "fed5199e-9aca-42b7-b279-ca1a7eb49032",
+                "resources": [
+                    "alerts"
+                ],
+                "inputVariables": [
+                    {
+                        "name": "sAMLEmailIDs",
+                        "type": "string",
+                        "label": "SAML Email IDs",
+                        "title": "Text Area",
+                        "usable": true,
+                        "tooltip": "Comma-separated list of Email IDs of existing users to convert to SAML",
+                        "dataType": "text",
+                        "formType": "textarea",
+                        "required": true,
+                        "_expanded": true,
+                        "mmdUpdate": true,
+                        "collection": false,
+                        "searchable": true,
+                        "templateUrl": "app\/components\/form\/fields\/textarea.html",
+                        "defaultValue": "email1@domain.com,email2@domain.com,...",
+                        "_previousName": "sAMLEmail",
+                        "lengthConstraint": true,
+                        "allowedEncryption": true,
+                        "allowedGridColumn": true,
+                        "jinjaExpressionView": true,
+                        "useRecordFieldDefault": false
+                    }
+                ],
+                "step_variables": {
+                    "input": {
+                        "params": {
+                            "sAMLEmailIDs": "{{vars.request.data[\"sAMLEmailIDs\"]}}"
+                        },
+                        "records": "{{vars.input.records}}"
+                    }
+                },
+                "_promptexpanded": true,
+                "executeButtonText": "Convert",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+            },
+            "status": null,
+            "top": "30",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+            "group": null,
+            "uuid": "573c55f0-6c59-4957-bb55-83381f91d595"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update User Type to SAML",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.emails}}",
+                    "parallel": false,
+                    "condition": ""
+                },
+                "arguments": {
+                    "email": "{{vars.item}}",
+                    "userType": "{{vars.user_type}}",
+                    "fsrHostname": "{{vars.fsr_hostname}}"
+                },
+                "apply_async": false,
+                "step_variables": [],
+                "pass_parent_env": false,
+                "pass_input_record": false,
+                "workflowReference": "\/api\/3\/workflows\/b0223472-16ac-4e4b-a34c-4642961fafe1"
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "f57e640b-0aec-40d5-bf8e-8c35a33b7b63"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Set variables -> Reference import sub playbook",
+            "targetStep": "\/api\/3\/workflow_steps\/f57e640b-0aec-40d5-bf8e-8c35a33b7b63",
+            "sourceStep": "\/api\/3\/workflow_steps\/58c7c031-0e0c-4d18-b7bc-3e7c24d6084b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "c924c7be-32c5-42cc-b258-50621e7d84ed"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/58c7c031-0e0c-4d18-b7bc-3e7c24d6084b",
+            "sourceStep": "\/api\/3\/workflow_steps\/573c55f0-6c59-4957-bb55-83381f91d595",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "83e32833-f3b1-4396-9179-0c24673ccc58"
+        }
+    ],
+    "groups": [],
+    "priority": null,
+    "uuid": "b22a9238-a66f-4063-8b8f-aa8ff430c943",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "ManualTrigger",
+        "Utilities"
+    ]
+}

--- a/playbooks/08 - Utilities/Convert FortiSOAR User to SAML - Collect User Email IDs.json
+++ b/playbooks/08 - Utilities/Convert FortiSOAR User to SAML - Collect User Email IDs.json
@@ -37,6 +37,7 @@
             "description": null,
             "arguments": {
                 "route": "fed5199e-9aca-42b7-b279-ca1a7eb49032",
+                "title": "Convert FortiSOAR User to SAML",
                 "resources": [
                     "alerts"
                 ],

--- a/playbooks/08 - Utilities/Convert FortiSOAR User to SAML - Update User Type.json
+++ b/playbooks/08 - Utilities/Convert FortiSOAR User to SAML - Update User Type.json
@@ -1,0 +1,262 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Convert FortiSOAR User to SAML - Update User Type",
+    "aliasName": null,
+    "tag": null,
+    "description": "Updates user type of existing FortiSOAR user to SAML.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [
+        "email",
+        "userType",
+        "fsrHostname"
+    ],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/20289298-cdd6-4052-8fa0-11e2603dca00",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/d2f55cf4-f0d5-45ba-aeda-5f5f98a997ae",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "userRoleIRI": "\/api\/3\/roles\/0129ff4b-fe2c-49cd-b5ca-18d3e04d1a8a",
+                "userTeamIRI": "\/api\/3\/teams\/6e569c09-3bd4-40f1-98b0-cc994464c3c5"
+            },
+            "status": null,
+            "top": "165",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "ae8f4c8f-fdc9-4682-8573-951aeb916c9e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find User by Email",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "email",
+                            "value": "{{vars.input.params.email}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "userId",
+                        "email"
+                    ]
+                },
+                "module": "people?$limit=30",
+                "checkboxFields": true,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "b547aac1-d98d-45f5-9b33-087271cf1f92"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is User Found",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/b231f1ed-3577-45af-980d-29098e0587ef",
+                        "condition": "{{ vars.steps.Find_User_by_Email | length > 0 }}",
+                        "step_name": "Update User to SSO User"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/09773e06-a866-497c-ac7d-54fc2a89da34",
+                        "step_name": "Error message"
+                    }
+                ]
+            },
+            "status": null,
+            "top": "435",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "18f7e326-7389-48a9-8d41-261276267223"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Raise User Not Found Exception",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "msg": "User with Email ID {{vars.input.params.email}} is not found in FortiSOAR."
+                },
+                "version": "3.2.3",
+                "connector": "cyops_utilities",
+                "operation": "raise_exception",
+                "ignore_errors": true,
+                "operationTitle": "Utils: Raise Exception",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "560",
+            "left": "120",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "09773e06-a866-497c-ac7d-54fc2a89da34"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "step_variables": {
+                    "input": {
+                        "params": {
+                            "email": "{{ vars.email }}",
+                            "userType": "{{ vars.userType }}",
+                            "userConfig": "{{ vars.userConfig }}",
+                            "fsrHostname": "{{ vars.fsrHostname }}"
+                        }
+                    }
+                }
+            },
+            "status": null,
+            "top": "30",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+            "group": null,
+            "uuid": "d2f55cf4-f0d5-45ba-aeda-5f5f98a997ae"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update User to SSO User",
+            "description": "Update user to SSO User by modifying user_type value to '6'",
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/auth\/users",
+                    "body": "{{ {\"update\":{\"loginid\":vars.input.params.email,\"domain\":vars.input.params.fsrHostname,\"user_type\":vars.input.params.userType,\"tenant\":\"crudhub\",\"uuid\":vars.steps.Find_User_by_Email[0].userId}} }}",
+                    "method": "PUT"
+                },
+                "version": "3.2.3",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "b231f1ed-3577-45af-980d-29098e0587ef"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update User Type to SAML",
+            "description": "Update value of `User Type` to \"SAML\" in user's People record",
+            "arguments": {
+                "params": {
+                    "iri": "{{vars.steps.Find_User_by_Email[0]['@id']}}",
+                    "body": "{\"userType\": \"SAML\"}",
+                    "method": "PUT"
+                },
+                "version": "3.2.3",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "22878064-7da3-47f4-86f9-1d2369e4786c"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Config -> Find person by email",
+            "targetStep": "\/api\/3\/workflow_steps\/b547aac1-d98d-45f5-9b33-087271cf1f92",
+            "sourceStep": "\/api\/3\/workflow_steps\/ae8f4c8f-fdc9-4682-8573-951aeb916c9e",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "4ed22d1b-f499-46e4-a934-61af463234b0"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Create user -> Create people record",
+            "targetStep": "\/api\/3\/workflow_steps\/22878064-7da3-47f4-86f9-1d2369e4786c",
+            "sourceStep": "\/api\/3\/workflow_steps\/b231f1ed-3577-45af-980d-29098e0587ef",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "1278ec6b-3348-469f-a575-3b293a0ff19d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find User by Email -> Is User Found",
+            "targetStep": "\/api\/3\/workflow_steps\/18f7e326-7389-48a9-8d41-261276267223",
+            "sourceStep": "\/api\/3\/workflow_steps\/b547aac1-d98d-45f5-9b33-087271cf1f92",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9f95d5c8-49c1-435b-a65c-b942cfbe7389"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is User Found -> Error message",
+            "targetStep": "\/api\/3\/workflow_steps\/09773e06-a866-497c-ac7d-54fc2a89da34",
+            "sourceStep": "\/api\/3\/workflow_steps\/18f7e326-7389-48a9-8d41-261276267223",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "354e3264-7232-4ca4-8366-585a2c1e8c01"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is User Found -> Update User to SSO User",
+            "targetStep": "\/api\/3\/workflow_steps\/b231f1ed-3577-45af-980d-29098e0587ef",
+            "sourceStep": "\/api\/3\/workflow_steps\/18f7e326-7389-48a9-8d41-261276267223",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d10195e2-7b69-450f-af88-8f22b75a82d5"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Config",
+            "targetStep": "\/api\/3\/workflow_steps\/ae8f4c8f-fdc9-4682-8573-951aeb916c9e",
+            "sourceStep": "\/api\/3\/workflow_steps\/d2f55cf4-f0d5-45ba-aeda-5f5f98a997ae",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "7739f247-044a-4139-ad5b-5abd5378a180"
+        }
+    ],
+    "groups": [],
+    "priority": null,
+    "uuid": "b0223472-16ac-4e4b-a34c-4642961fafe1",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "Referenced",
+        "Utilities"
+    ]
+}


### PR DESCRIPTION
>Mantis#915374
- Validated that the "File Content Extractor" Connector is successfully installed while deploying SFSP

> Mantis#0907754
- Validated that new playbooks `Convert FortiSOAR User to SAML - Update User Type` and `Convert FortiSOAR User to SAML - Collect User Email IDs` is added to the *08 - Utilities* collection
- Validated that existing FortiSOAR user is getting updated to the SAML(SSO) user

> Mantis#0914022
- Validated that the new playbook `Extract Indicators from Attachments` is added to the *03 - Enrich* collection and added to the `Extract Indicators` playbook as a reference playbook
- Validated that indicators for email attachments are getting extracted and created for `Phishing` or `Suspicious Email` type of alerts