### PR TITLE
QA BugFixes

### DIFF
--- a/modules/sla_template/mmd.json
+++ b/modules/sla_template/mmd.json
@@ -860,7 +860,7 @@
             "skipSerialization": false,
             "displayName": "{{ restartSLA }}",
             "descriptions": {
-                "singular": "Restart SLA?"
+                "singular": "Restart SLA"
             }
         }
     ],

--- a/playbooks/03 - Enrich/Enrich Indicator (Type IP).json
+++ b/playbooks/03 - Enrich/Enrich Indicator (Type IP).json
@@ -42,17 +42,17 @@
             "name": "Reverse DNS",
             "description": null,
             "arguments": {
-              "config": "0e7a1d6d-1ab7-4d97-bbd3-f680d4dc676a",
-              "params": {
-                "python_function": "try:\n    import dns.resolver,dns.reversename\n    addrs = dns.reversename.from_address(\"{{vars.record}}\")\n    print(str(dns.resolver.query(addrs,\"PTR\")[0]))\nexcept:\n    print('Not Resolvable')"
-              },
-              "version": "2.0.3",
-              "connector": "code-snippet",
-              "operation": "python_inline_code_editor",
-              "operationTitle": "Execute Python Code",
-              "step_variables": {
-                "hostname": "{{vars.result.data['code_output']}}"
-              }
+                "config": "0e7a1d6d-1ab7-4d97-bbd3-f680d4dc676a",
+                "params": {
+                    "python_function": "try:\n    import dns.resolver,dns.reversename\n    addrs = dns.reversename.from_address(\"{{vars.record}}\")\n    print(str(dns.resolver.query(addrs,\"PTR\")[0]))\nexcept:\n    print('Not Resolvable')"
+                },
+                "version": "2.0.3",
+                "connector": "code-snippet",
+                "operation": "python_inline_code_editor",
+                "operationTitle": "Execute Python Code",
+                "step_variables": {
+                    "hostname": "{{vars.result.data['code_output']}}"
+                }
             },
             "status": null,
             "top": "380",

--- a/playbooks/03 - Enrich/Enrich Indicator (Type IP).json
+++ b/playbooks/03 - Enrich/Enrich Indicator (Type IP).json
@@ -42,17 +42,17 @@
             "name": "Reverse DNS",
             "description": null,
             "arguments": {
-                "config": "0e7a1d6d-1ab7-4d97-bbd3-f680d4dc676a",
-                "params": {
-                    "python_function": "try:\n    import dns.resolver,dns.reversename\n    addrs = dns.reversename.from_address(\"{{vars.record}}\")\n    print(str(dns.resolver.query(addrs,\"PTR\")[0]))\nexcept:\n    print('Not Resolvable')"
-                },
-                "version": "2.0.0",
-                "connector": "code-snippet",
-                "operation": "python_inline",
-                "operationTitle": "Execute Python Code",
-                "step_variables": {
-                    "hostname": "{{vars.result.data['code_output']}}"
-                }
+              "config": "0e7a1d6d-1ab7-4d97-bbd3-f680d4dc676a",
+              "params": {
+                "python_function": "try:\n    import dns.resolver,dns.reversename\n    addrs = dns.reversename.from_address(\"{{vars.record}}\")\n    print(str(dns.resolver.query(addrs,\"PTR\")[0]))\nexcept:\n    print('Not Resolvable')"
+              },
+              "version": "2.0.3",
+              "connector": "code-snippet",
+              "operation": "python_inline_code_editor",
+              "operationTitle": "Execute Python Code",
+              "step_variables": {
+                "hostname": "{{vars.result.data['code_output']}}"
+              }
             },
             "status": null,
             "top": "380",

--- a/playbooks/03 - Enrich/Enrich Indicators (Type All).json
+++ b/playbooks/03 - Enrich/Enrich Indicators (Type All).json
@@ -499,7 +499,9 @@
             "name": "Exit",
             "description": null,
             "arguments": {
-                "temp": "no_op"
+              "reputation": "No Reputation Available",
+              "reputation_iri": "{{\"IndicatorReputation\" | picklist(\"No Reputation Available\", \"@id\")}}",
+              "enrichment_summaries": ""
             },
             "status": null,
             "top": "560",

--- a/playbooks/03 - Enrich/Extract Indicators from Attachments.json
+++ b/playbooks/03 - Enrich/Extract Indicators from Attachments.json
@@ -6,7 +6,7 @@
     "tag": null,
     "description": "Enriches Attachment with extracted text, indicators and Meta data",
     "isActive": true,
-    "debug": true,
+    "debug": false,
     "singleRecordExecution": false,
     "remoteExecutableFlag": false,
     "parameters": [

--- a/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger).json
+++ b/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger).json
@@ -155,14 +155,14 @@
                 "step_variables": {
                     "incident": "{{ vars.result }}"
                 }
-                },
-                "status": null,
-                "top": "570",
-                "left": "125",
-                "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
-                "group": null,
-                "uuid": "86b78abf-9efc-4c75-811c-329128019f23"
             },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "86b78abf-9efc-4c75-811c-329128019f23"
+        },
         {
             "@type": "WorkflowStep",
             "name": "Set Escalate Status on Alert",

--- a/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger).json
+++ b/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger).json
@@ -119,50 +119,50 @@
             "uuid": "b600dcb0-3476-477e-a108-4426b8e9e092"
         },
         {
-            "@type": "WorkflowStep",
-            "name": "Insert One Incident_Many_to_One",
-            "description": null,
-            "arguments": {
-              "resource": {
-                "name": "{{vars.input.params.incidentName}}",
-                "phase": "\/api\/3\/picklists\/bb740542-f699-11e7-8c3f-9a214cf093ae",
-                "alerts": "{{ vars.input.params.records | json_query('[*].\"@id\"[]') }}",
-                "assets": "{{vars.sorted_assets_list or None}}",
-                "owners": "{{vars.input.params.incidentOwners}}",
-                "resSla": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
-                "status": "\/api\/3\/picklists\/bb73fe9e-f699-11e7-8c3f-9a214cf093ae",
-                "tenant": "{{vars.input.params.sharedTenantIRI}}",
-                "category": "{{vars.input.params.incidentType or None}}",
-                "severity": "{{vars.input.params.severity or None}}",
-                "slaState": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
-                "__replace": "",
-                "indicators": "{{vars.sorted_indicator_list or None}}",
-                "incidentLead": "{{vars.input.params.incidentLead or None}}",
-                "mitresoftware": "{{vars.sorted_software_list or None}}",
-                "slaPercentage": 0,
-                "mitretechniques": "{{vars.sorted_technique_list or None}}",
-                "mitremitigations": "{{vars.soreted_mitigation_list or None}}",
-                "mitresubtechniques": "{{vars.sorted_sub_technique_list or None}}"
-              },
-              "_showJson": false,
-              "operation": "Overwrite",
-              "collection": "\/api\/3\/incidents",
-              "__recommend": [],
-              "tagsOperation": "OverwriteTags",
-              "fieldOperation": {
-                "recordTags": "Overwrite"
-              },
-              "step_variables": {
-                "incident": "{{ vars.result }}"
-              }
+                "@type": "WorkflowStep",
+                "name": "Insert One Incident_Many_to_One",
+                "description": null,
+                "arguments": {
+                "resource": {
+                    "name": "{{vars.input.params.incidentName}}",
+                    "phase": "\/api\/3\/picklists\/bb740542-f699-11e7-8c3f-9a214cf093ae",
+                    "alerts": "{{ vars.input.params.records | json_query('[*].\"@id\"[]') }}",
+                    "assets": "{{vars.sorted_assets_list or None}}",
+                    "owners": "{{vars.input.params.incidentOwners}}",
+                    "resSla": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
+                    "status": "\/api\/3\/picklists\/bb73fe9e-f699-11e7-8c3f-9a214cf093ae",
+                    "tenant": "{{vars.input.params.sharedTenantIRI}}",
+                    "category": "{{vars.input.params.incidentType or None}}",
+                    "severity": "{{vars.input.params.severity or None}}",
+                    "slaState": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
+                    "__replace": "",
+                    "indicators": "{{vars.sorted_indicator_list or None}}",
+                    "incidentLead": "{{vars.input.params.incidentLead or None}}",
+                    "mitresoftware": "{{vars.sorted_software_list or None}}",
+                    "slaPercentage": 0,
+                    "mitretechniques": "{{vars.sorted_technique_list or None}}",
+                    "mitremitigations": "{{vars.soreted_mitigation_list or None}}",
+                    "mitresubtechniques": "{{vars.sorted_sub_technique_list or None}}"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/incidents",
+                "__recommend": [],
+                "tagsOperation": "OverwriteTags",
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": {
+                    "incident": "{{ vars.result }}"
+                }
+                },
+                "status": null,
+                "top": "570",
+                "left": "125",
+                "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+                "group": null,
+                "uuid": "86b78abf-9efc-4c75-811c-329128019f23"
             },
-            "status": null,
-            "top": "570",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
-            "group": null,
-            "uuid": "86b78abf-9efc-4c75-811c-329128019f23"
-          },
         {
             "@type": "WorkflowStep",
             "name": "Set Escalate Status on Alert",

--- a/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger).json
+++ b/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger).json
@@ -123,38 +123,38 @@
             "name": "Insert One Incident_Many_to_One",
             "description": null,
             "arguments": {
-                "resource": {
-                    "name": "{{vars.input.params.incidentName}}",
-                    "phase": "\/api\/3\/picklists\/bb740542-f699-11e7-8c3f-9a214cf093ae",
-                    "alerts": "{{ vars.input.params.records | json_query('[*].\"@id\"[]') }}",
-                    "assets": "{{vars.sorted_assets_list or None}}",
-                    "owners": "{{vars.input.params.incidentOwners}}",
-                    "resSla": "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
-                    "status": "\/api\/3\/picklists\/bb73fe9e-f699-11e7-8c3f-9a214cf093ae",
-                    "tenant": "{{vars.input.params.sharedTenantIRI}}",
-                    "category": "{{vars.input.params.incidentType or None}}",
-                    "severity": "{{vars.input.params.severity or None}}",
-                    "slaState": "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
-                    "__replace": "",
-                    "indicators": "{{vars.sorted_indicator_list or None}}",
-                    "incidentLead": "{{vars.input.params.incidentLead or None}}",
-                    "mitresoftware": "{{vars.sorted_software_list or None}}",
-                    "slaPercentage": 0,
-                    "mitretechniques": "{{vars.sorted_technique_list or None}}",
-                    "mitremitigations": "{{vars.soreted_mitigation_list or None}}",
-                    "mitresubtechniques": "{{vars.sorted_sub_technique_list or None}}"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "\/api\/3\/incidents",
-                "__recommend": [],
-                "tagsOperation": "OverwriteTags",
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": {
-                    "incident": "{{ vars.result }}"
-                }
+              "resource": {
+                "name": "{{vars.input.params.incidentName}}",
+                "phase": "\/api\/3\/picklists\/bb740542-f699-11e7-8c3f-9a214cf093ae",
+                "alerts": "{{ vars.input.params.records | json_query('[*].\"@id\"[]') }}",
+                "assets": "{{vars.sorted_assets_list or None}}",
+                "owners": "{{vars.input.params.incidentOwners}}",
+                "resSla": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
+                "status": "\/api\/3\/picklists\/bb73fe9e-f699-11e7-8c3f-9a214cf093ae",
+                "tenant": "{{vars.input.params.sharedTenantIRI}}",
+                "category": "{{vars.input.params.incidentType or None}}",
+                "severity": "{{vars.input.params.severity or None}}",
+                "slaState": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
+                "__replace": "",
+                "indicators": "{{vars.sorted_indicator_list or None}}",
+                "incidentLead": "{{vars.input.params.incidentLead or None}}",
+                "mitresoftware": "{{vars.sorted_software_list or None}}",
+                "slaPercentage": 0,
+                "mitretechniques": "{{vars.sorted_technique_list or None}}",
+                "mitremitigations": "{{vars.soreted_mitigation_list or None}}",
+                "mitresubtechniques": "{{vars.sorted_sub_technique_list or None}}"
+              },
+              "_showJson": false,
+              "operation": "Overwrite",
+              "collection": "\/api\/3\/incidents",
+              "__recommend": [],
+              "tagsOperation": "OverwriteTags",
+              "fieldOperation": {
+                "recordTags": "Overwrite"
+              },
+              "step_variables": {
+                "incident": "{{ vars.result }}"
+              }
             },
             "status": null,
             "top": "570",
@@ -162,7 +162,7 @@
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "86b78abf-9efc-4c75-811c-329128019f23"
-        },
+          },
         {
             "@type": "WorkflowStep",
             "name": "Set Escalate Status on Alert",

--- a/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger).json
+++ b/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger).json
@@ -119,10 +119,10 @@
             "uuid": "b600dcb0-3476-477e-a108-4426b8e9e092"
         },
         {
-                "@type": "WorkflowStep",
-                "name": "Insert One Incident_Many_to_One",
-                "description": null,
-                "arguments": {
+            "@type": "WorkflowStep",
+            "name": "Insert One Incident_Many_to_One",
+            "description": null,
+            "arguments": {
                 "resource": {
                     "name": "{{vars.input.params.incidentName}}",
                     "phase": "\/api\/3\/picklists\/bb740542-f699-11e7-8c3f-9a214cf093ae",

--- a/playbooks/06 - IRP - Case Management/Alert - [03] Capture Response SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Alert - [03] Capture Response SLA (Upon Update).json
@@ -129,7 +129,7 @@
                 "config": "4b6b27cf-86a5-4c5d-a7f8-0186dbc623b5",
                 "params": {
                     "slaTime": "{% if vars.input.records[0].alertRemainingRespSLA%}{{vars.input.records[0].alertRemainingRespSLA}}{%else%}{{vars.sla_time_list.alertResTime}}{%endif%}",
-                    "recordCreateTime": "{% if vars.sla_time_list == True%} {{vars.input.records[0].modifyDate}} {% else %} {{vars.input.records[0].createDate}} {% endif %}"
+                    "recordCreateTime": "{% if vars.sla_time_list %} {{vars.input.records[0].modifyDate}} {% else %} {{vars.input.records[0].createDate}} {% endif %}"
                 },
                 "version": "2.0.0",
                 "connector": "slacalculator",

--- a/records/sla_template/sla_template0001.json
+++ b/records/sla_template/sla_template0001.json
@@ -1,6 +1,7 @@
 [
     {
         "@type": "SLATemplate",
+        "restartSLA": false,
         "alertAckTime": "70",
         "ackSlaTime": "70",
         "resTime": "80",
@@ -24,6 +25,7 @@
     },
     {
         "@type": "SLATemplate",
+        "restartSLA": false,
         "alertAckTime": "10",
         "ackSlaTime": "10",
         "resTime": "20",
@@ -47,6 +49,7 @@
     },
     {
         "@type": "SLATemplate",
+        "restartSLA": false,
         "alertAckTime": "40",
         "ackSlaTime": "40",
         "resTime": "50",
@@ -70,6 +73,7 @@
     },
     {
         "@type": "SLATemplate",
+        "restartSLA": false,
         "alertAckTime": "20",
         "ackSlaTime": "20",
         "resTime": "30",
@@ -93,6 +97,7 @@
     },
     {
         "@type": "SLATemplate",
+        "restartSLA": false,
         "alertAckTime": "60",
         "ackSlaTime": "60",
         "resTime": "70",


### PR DESCRIPTION
UTCs 

> Mantis#0879152
- Validated that for the "Alert - [03] Capture Response SLA (Upon Update)" playbook the due date is getting recalculated correctly after we resume the alert from the pause
- Value for "Restart SLA" is added as `false` to all the OOB records of the SLA Templates
- Renamed field label from "Restart SLA?" to "Restart SLA"

> Mantis#0914437
- Validated that the IOC types such as Port, and Host when enriched manually, the `Enrich indicators (Type All)` playbook returns the result as “No Reputation Available”.

> Mantis#0914419
- Validated that in the "Enrich Indicator (Type IP)" playbook, for the step "Reverse DNS", the deprecated action of code snippet connector is replaced with the latest one

> Mantis#0910184
- Validated that the default value of "Ack SLA" and "Response SLA" is "Awaiting Action" for the step "Insert One Incident_Many_to_One" in 06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger) playbook