### PR TITLE
QA BugFixes

### DIFF
--- a/info.json
+++ b/info.json
@@ -406,8 +406,8 @@
             {
                 "id": 13,
                 "name": "Excludelist_Domains",
-                "value": "google.com,yahoo.com,fortinet.net,cybersponse.com,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com",
-                "default_value": "google.com,yahoo.com,fortinet.net,cybersponse.com,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com"
+                "value": "google.com,yahoo.com,fortinet.net,cybersponse.com,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com,w3.org",
+                "default_value": "google.com,yahoo.com,fortinet.net,cybersponse.com,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com,w3.org"
             },
             {
                 "id": 15,

--- a/modules/keys/detail-layout.json
+++ b/modules/keys/detail-layout.json
@@ -9,6 +9,23 @@
                     {
                         "widgets": [
                             {
+                                "type": "primaryDetail",
+                                "config": {
+                                    "wid": "d35a747c-e49e-4f7b-9079-1ecf9147357c",
+                                    "idField": "id",
+                                    "picklistFieldReadOnly": false,
+                                    "titleFieldReadOnly": true,
+                                    "featuredRelationship": {
+                                        "field": null,
+                                        "preText": "Under Investigation In",
+                                        "query": null,
+                                        "statusField": null,
+                                        "sort": []
+                                    },
+                                    "titleField": "key"
+                                }
+                            },
+                            {
                                 "type": "editableFormGroup",
                                 "config": {
                                     "wid": "2abd6f60-cd32-438a-8dbe-f37f2aed228c",

--- a/playbooks/03 - Enrich/Extract Indicators from Attachments.json
+++ b/playbooks/03 - Enrich/Extract Indicators from Attachments.json
@@ -4,7 +4,7 @@
     "name": "Extract Indicators from Attachments",
     "aliasName": null,
     "tag": null,
-    "description": "Enriches Attachment with extracted text, indicators and Meta data",
+    "description": "Extracts indicators from the attachment of the suspicious email",
     "isActive": true,
     "debug": false,
     "singleRecordExecution": false,

--- a/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger).json
+++ b/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (No Trigger).json
@@ -31,7 +31,8 @@
             "arguments": {
                 "for_each": {
                     "item": "{{vars.steps.Get_Related_Records}}",
-                    "parallel": false,
+                    "__bulk": false,
+                    "parallel": true,
                     "condition": ""
                 },
                 "temp_var1": "{{vars.asset_list.extend(vars.item.assets_record_list)}}",
@@ -39,7 +40,9 @@
                 "temp_var3": "{{vars.mitigation_list.extend(vars.item.mitigation_record_list)}}",
                 "temp_var4": "{{vars.software_list.extend(vars.item.software_record_list)}}",
                 "temp_var5": "{{vars.sub_technique_list.extend(vars.item.sub_technique_record_IRI)}}",
-                "temp_var6": "{{vars.technique_list.extend(vars.item.technique_record_IRI)}}"
+                "temp_var6": "{{vars.technique_list.extend(vars.item.technique_record_IRI)}}",
+                "temp_var7": "{{vars.tactics_list.extend(vars.item.tactics_record_IRI)}}",
+                "temp_var8": "{{vars.group_list.extend(vars.item.group_record_IRI)}}"
             },
             "status": null,
             "top": "300",
@@ -80,11 +83,13 @@
             "name": "Get Unique Related Records",
             "description": null,
             "arguments": {
+                "sorted_group_list": "{{vars.group_list | flatten | unique }}",
                 "sorted_assets_list": "{{vars.asset_list | flatten | unique }}",
+                "sorted_tactics_list": "{{vars.tactics_list | flatten | unique }}",
                 "sorted_software_list": "{{vars.software_list | flatten | unique }}",
                 "sorted_indicator_list": "{{vars.indicator_list | flatten | unique }}",
                 "sorted_technique_list": "{{vars.technique_list | flatten | unique }}",
-                "soreted_mitigation_list": "{{vars.mitigation_list | flatten | unique }}",
+                "sorted_mitigation_list": "{{vars.mitigation_list | flatten | unique }}",
                 "sorted_sub_technique_list": "{{vars.sub_technique_list | flatten | unique }}"
             },
             "status": null,
@@ -137,11 +142,13 @@
                     "slaState": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
                     "__replace": "",
                     "indicators": "{{vars.sorted_indicator_list or None}}",
+                    "mitregroups": "{{vars.sorted_group_list or None}}",
                     "incidentLead": "{{vars.input.params.incidentLead or None}}",
+                    "mitretactics": "{{vars.sorted_tactics_list or None}}",
                     "mitresoftware": "{{vars.sorted_software_list or None}}",
                     "slaPercentage": 0,
                     "mitretechniques": "{{vars.sorted_technique_list or None}}",
-                    "mitremitigations": "{{vars.soreted_mitigation_list or None}}",
+                    "mitremitigations": "{{vars.sorted_mitigation_list or None}}",
                     "mitresubtechniques": "{{vars.sorted_sub_technique_list or None}}"
                 },
                 "_showJson": false,
@@ -223,6 +230,8 @@
                         "params": []
                     },
                     "asset_list": "[]",
+                    "group_list": "[]",
+                    "tactics_list": "[]",
                     "software_list": "[]",
                     "indicator_list": "[]",
                     "technique_list": "[]",

--- a/playbooks/06 - IRP - Case Management/Alert - Escalate to Incident (Link Relations).json
+++ b/playbooks/06 - IRP - Case Management/Alert - Escalate to Incident (Link Relations).json
@@ -56,7 +56,9 @@
             "name": "Return Related Records",
             "description": null,
             "arguments": {
+                "group_record_IRI": "{{vars.related_records['mitregroups']}}",
                 "assets_record_list": "{{vars.related_records.assets}}",
+                "tactics_record_IRI": "{{vars.related_records['mitretactics']}}",
                 "software_record_list": "{{vars.related_records['mitresoftware']}}",
                 "technique_record_IRI": "{{vars.related_records['mitre_techniques']}}",
                 "indicators_record_list": "{{vars.related_records.indicators}}",
@@ -74,16 +76,6 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Get Related Records",
-            "targetStep": "\/api\/3\/workflow_steps\/ab9b59a4-3997-44a5-a108-9c81dcea1019",
-            "sourceStep": "\/api\/3\/workflow_steps\/80feedc6-5b5e-42bc-a187-209a56af95fb",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "5b9ac819-c97a-4787-b87d-334c7c310d61"
-        },
-        {
-            "@type": "WorkflowRoute",
             "name": "Get Related Records -> Return Related Records",
             "targetStep": "\/api\/3\/workflow_steps\/6d97d184-9e07-47e2-9ca9-b524c344c404",
             "sourceStep": "\/api\/3\/workflow_steps\/ab9b59a4-3997-44a5-a108-9c81dcea1019",
@@ -91,6 +83,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "85b8226d-f40e-46d6-bbfb-2867d9e80b4a"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Get Related Records",
+            "targetStep": "\/api\/3\/workflow_steps\/ab9b59a4-3997-44a5-a108-9c81dcea1019",
+            "sourceStep": "\/api\/3\/workflow_steps\/80feedc6-5b5e-42bc-a187-209a56af95fb",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "5b9ac819-c97a-4787-b87d-334c7c310d61"
         }
     ],
     "groups": [],


### PR DESCRIPTION
###UTCs

- Validated that description for playbook `03 - Enrich > Extract Indicators from Attachments`

> Mantis#916449
- Validated that the `Primary Details` widget is added to the `Key Store` module

> Mantis#0916210
- Validated that the `w3.org` is added to the excluded domain list in a global variable Excludelist_Domains

> Mantis#0909793
- Validated that the mitre modules such as Group and tactics are getting correlated to the escalated incident