### PR TITLE
QA Bug Fixes - 1

### DIFF
--- a/modules/assets/detail-layout.json
+++ b/modules/assets/detail-layout.json
@@ -356,7 +356,8 @@
                                                                                                     "assetChangeActivities",
                                                                                                     "cVEs",
                                                                                                     "iCSAdvisories",
-                                                                                                    "kEVAlerts"
+                                                                                                    "kEVAlerts",
+                                                                                                    "companies"
                                                                                                 ],
                                                                                                 "expandableCol": [],
                                                                                                 "wid": "a6c0e83d-2f8d-4156-9d55-44e4890e89f7",


### PR DESCRIPTION
> Mantis#0911550
- Validated the removal of the 'Companies' module from the 'Correlations' tab in the Detailed View of Assets.