### PR TITLE
BugFixes-4

### DIFF
--- a/info.json
+++ b/info.json
@@ -477,6 +477,12 @@
                 "name": "User_Enrichment_Playbooks_IRIs",
                 "value": "NoEnrichmentAvailable",
                 "default_value": "NoEnrichmentAvailable"
+            },
+            {
+                "id": 36,
+                "name": "Excludelist_Files",
+                "value": "",
+                "default_value": ""
             }
         ],
         "playbookBlocks": [

--- a/playbooks/03 - Enrich/Enrich Indicators (Type All).json
+++ b/playbooks/03 - Enrich/Enrich Indicators (Type All).json
@@ -633,6 +633,7 @@
             "arguments": {
                 "when": "{{not vars.input.params['indicator_value'] == None}}",
                 "resource": {
+                    "indicatorStatus": "{% if vars.indicator_type == 'File' and 'Excluded' in (vars.indicator_iri | fromIRI).recordTags %}{{\"IndicatorStatus\" | picklist(\"Excluded\", \"@id\")}}{% else %}{{\"IndicatorStatus\" | picklist(\"TBD\", \"@id\")}}{% endif %}",
                     "enrichmentStatus": "\/api\/3\/picklists\/8a4609d2-8a3d-4bda-9888-5f00bfea43cb"
                 },
                 "_showJson": false,

--- a/playbooks/03 - Enrich/Extract Indicators - Create File Indicator.json
+++ b/playbooks/03 - Enrich/Extract Indicators - Create File Indicator.json
@@ -1,7 +1,7 @@
 {
     "@type": "Workflow",
     "triggerLimit": null,
-    "name": "Extract Indicators > Create File Indicators",
+    "name": "Extract Indicators - Create File Indicator",
     "aliasName": null,
     "tag": null,
     "description": "Create File IOCs extracted from suspicious email attachments",
@@ -35,7 +35,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "300",
+            "top": "165",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
@@ -79,7 +79,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
+            "top": "435",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -95,7 +95,8 @@
                     "file": "{{vars.input.params.fileIRI}}",
                     "value": "File - {{vars.steps.Compute_Hash.data.filename}} - {{vars.steps.Compute_Hash.data.md5}}",
                     "__link": {
-                        "alerts": "{{vars.input.params.alertIRI}}"
+                        "alerts": "{{vars.input.params.alertIRI}}",
+                        "recordTags": "{% if vars.input.params.isExcluded %}Excluded{% endif %}"
                     },
                     "tenant": "{{vars.input.params.tenantIRI}}",
                     "lastSeen": "{{arrow.utcnow().int_timestamp}}",
@@ -107,7 +108,7 @@
                     "filehashSHA1": "{{vars.steps.Compute_Hash.data.sha1}}",
                     "expiredStatus": "\/api\/3\/picklists\/d4ca4a72-7974-4b93-843e-da9efa235c6e",
                     "filehashSHA256": "{{vars.steps.Compute_Hash.data.sha256}}",
-                    "indicatorStatus": "{% if vars.input.params.isExcluded %}{{\"IndicatorStatus\" | picklist(\"Excluded\", \"@id\")}}{% else %}{{\"IndicatorStatus\" | picklist(\"TBD\", \"@id\")}}{% endif %}",
+                    "indicatorStatus": "\/api\/3\/picklists\/2f5cff61-fbff-4bb3-96be-302b78a9fb47",
                     "typeofindicator": "\/api\/3\/picklists\/0162241b-f5bf-4917-a150-00e920be47bd",
                     "__fieldsToUpdate": [
                         "lastSeen",
@@ -125,58 +126,11 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
+            "top": "300",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "7b8a17b1-0062-448b-9141-6a27ead0559c"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Is Excluded",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Yes",
-                        "step_iri": "\/api\/3\/workflow_steps\/4b2c95e2-4e5a-43a0-8b2c-c7d883606a5f",
-                        "condition": "{{ vars.input.params.isExcluded }}",
-                        "step_name": "No Ops"
-                    },
-                    {
-                        "option": "No",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/f8a65627-7b35-4c9d-ab23-8701aa426baa",
-                        "step_name": "Compute Hash"
-                    }
-                ],
-                "step_variables": []
-            },
-            "status": null,
-            "top": "165",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "b5d4b5cb-a1ec-41e0-90c6-6e7fc261154c"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "No Ops",
-            "description": null,
-            "arguments": {
-                "params": [],
-                "version": "3.2.4",
-                "connector": "cyops_utilities",
-                "operation": "no_op",
-                "operationTitle": "Utils: No Operation",
-                "step_variables": []
-            },
-            "status": null,
-            "top": "300",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "4b2c95e2-4e5a-43a0-8b2c-c7d883606a5f"
         },
         {
             "@type": "WorkflowStep",
@@ -186,7 +140,7 @@
                 "file_ioc_details": "[\n  {\n    \"type\" : \"File\",\n    \"value\" : \"File - {{vars.steps.Compute_Hash.data.filename}} - {{vars.steps.Compute_Hash.data.md5}}\"\n  },\n  {\n    \"type\" : \"FileHash-MD5\",\n    \"value\" : \"{{vars.steps.Compute_Hash.data.md5}}\"\n  }\n]"
             },
             "status": null,
-            "top": "705",
+            "top": "570",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -205,7 +159,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "300",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
             "uuid": "c90f8dec-ce4f-44e9-954b-ee1dda573f0a"
@@ -244,33 +198,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Is Excluded -> Compute Hash",
+            "name": "Start -> Compute Hash",
             "targetStep": "\/api\/3\/workflow_steps\/f8a65627-7b35-4c9d-ab23-8701aa426baa",
-            "sourceStep": "\/api\/3\/workflow_steps\/b5d4b5cb-a1ec-41e0-90c6-6e7fc261154c",
-            "label": "No",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "e1176ab4-2c3d-4b33-b77a-84214de08b54"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is Excluded -> No Ops",
-            "targetStep": "\/api\/3\/workflow_steps\/4b2c95e2-4e5a-43a0-8b2c-c7d883606a5f",
-            "sourceStep": "\/api\/3\/workflow_steps\/b5d4b5cb-a1ec-41e0-90c6-6e7fc261154c",
-            "label": "Yes",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "b9394401-cac6-46d6-9812-7df20bf51576"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Start -> Is Excluded",
-            "targetStep": "\/api\/3\/workflow_steps\/b5d4b5cb-a1ec-41e0-90c6-6e7fc261154c",
             "sourceStep": "\/api\/3\/workflow_steps\/c90f8dec-ce4f-44e9-954b-ee1dda573f0a",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "018198dc-7151-44fb-a635-8a93edd4c754"
+            "uuid": "9b31ac7d-1b5b-4874-83f3-1248070f3c43"
         }
     ],
     "groups": [],

--- a/playbooks/03 - Enrich/Extract Indicators > Create File Indicators.json
+++ b/playbooks/03 - Enrich/Extract Indicators > Create File Indicators.json
@@ -1,0 +1,285 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Extract Indicators > Create File Indicators",
+    "aliasName": null,
+    "tag": null,
+    "description": "Create File IOCs extracted from suspicious email attachments",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [
+        "fileIRI",
+        "alertIRI",
+        "tenantIRI",
+        "isExcluded"
+    ],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/deaa4d19-7444-4f3a-a80e-9577436f25ef",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/c90f8dec-ce4f-44e9-954b-ee1dda573f0a",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Compute Hash",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "{{vars.input.params.fileIRI}}"
+                },
+                "version": "3.2.4",
+                "connector": "cyops_utilities",
+                "operation": "download_file_from_cyops",
+                "operationTitle": "File: Compute Hash",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "f8a65627-7b35-4c9d-ab23-8701aa426baa"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create FileHash MD5 Indicator",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "tlp": "\/api\/3\/picklists\/7bff95b7-6438-4b01-b23a-0fe8cb5b33d3",
+                    "value": "{{vars.steps.Compute_Hash.data.md5}}",
+                    "__link": {
+                        "alerts": "{{vars.input.params.alertIRI}}",
+                        "indicators": "{{vars.steps.Create_File_Indicator['@id']}}"
+                    },
+                    "tenant": "{{vars.input.params.tenantIRI}}",
+                    "lastSeen": "{{arrow.utcnow().int_timestamp}}",
+                    "__replace": "true",
+                    "firstSeen": "{{arrow.utcnow().int_timestamp}}",
+                    "expiryDate": "{{arrow.utcnow().shift(days=+(globalVars.Default_Indicator_TTL_Days | int)).timestamp}}",
+                    "reputation": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                    "expiredStatus": "\/api\/3\/picklists\/d4ca4a72-7974-4b93-843e-da9efa235c6e",
+                    "indicatorStatus": "\/api\/3\/picklists\/2f5cff61-fbff-4bb3-96be-302b78a9fb47",
+                    "typeofindicator": "\/api\/3\/picklists\/0ca054f2-d923-4992-a4a7-c516e6df281e",
+                    "__fieldsToUpdate": [
+                        "lastSeen",
+                        "alerts",
+                        "indicators"
+                    ],
+                    "enrichmentStatus": "\/api\/3\/picklists\/a6d9da29-27b1-4b8a-965d-8d91518540d5"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "\/api\/3\/upsert\/indicators",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "a76eb49b-66c1-40e1-b4f9-cdf0bd51a47d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create File Indicator",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "tlp": "\/api\/3\/picklists\/7bff95b7-6438-4b01-b23a-0fe8cb5b33d3",
+                    "file": "{{vars.input.params.fileIRI}}",
+                    "value": "File - {{vars.steps.Compute_Hash.data.filename}} - {{vars.steps.Compute_Hash.data.md5}}",
+                    "__link": {
+                        "alerts": "{{vars.input.params.alertIRI}}"
+                    },
+                    "tenant": "{{vars.input.params.tenantIRI}}",
+                    "lastSeen": "{{arrow.utcnow().int_timestamp}}",
+                    "__replace": "true",
+                    "firstSeen": "{{arrow.utcnow().int_timestamp}}",
+                    "expiryDate": "{{arrow.utcnow().shift(days=+(globalVars.Default_Indicator_TTL_Days | int)).timestamp}}",
+                    "reputation": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                    "filehashMD5": "{{vars.steps.Compute_Hash.data.md5}}",
+                    "filehashSHA1": "{{vars.steps.Compute_Hash.data.sha1}}",
+                    "expiredStatus": "\/api\/3\/picklists\/d4ca4a72-7974-4b93-843e-da9efa235c6e",
+                    "filehashSHA256": "{{vars.steps.Compute_Hash.data.sha256}}",
+                    "indicatorStatus": "{% if vars.input.params.isExcluded %}{{\"IndicatorStatus\" | picklist(\"Excluded\", \"@id\")}}{% else %}{{\"IndicatorStatus\" | picklist(\"TBD\", \"@id\")}}{% endif %}",
+                    "typeofindicator": "\/api\/3\/picklists\/0162241b-f5bf-4917-a150-00e920be47bd",
+                    "__fieldsToUpdate": [
+                        "lastSeen",
+                        "alerts"
+                    ],
+                    "enrichmentStatus": "\/api\/3\/picklists\/a6d9da29-27b1-4b8a-965d-8d91518540d5"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "\/api\/3\/upsert\/indicators",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "7b8a17b1-0062-448b-9141-6a27ead0559c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Excluded",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/4b2c95e2-4e5a-43a0-8b2c-c7d883606a5f",
+                        "condition": "{{ vars.input.params.isExcluded }}",
+                        "step_name": "No Ops"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/f8a65627-7b35-4c9d-ab23-8701aa426baa",
+                        "step_name": "Compute Hash"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "165",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "b5d4b5cb-a1ec-41e0-90c6-6e7fc261154c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "No Ops",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.2.4",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "4b2c95e2-4e5a-43a0-8b2c-c7d883606a5f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Result",
+            "description": null,
+            "arguments": {
+                "file_ioc_details": "[\n  {\n    \"type\" : \"File\",\n    \"value\" : \"File - {{vars.steps.Compute_Hash.data.filename}} - {{vars.steps.Compute_Hash.data.md5}}\"\n  },\n  {\n    \"type\" : \"FileHash-MD5\",\n    \"value\" : \"{{vars.steps.Compute_Hash.data.md5}}\"\n  }\n]"
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "97f1bfb8-4bba-4e01-84dd-bd7c373da824"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "step_variables": {
+                    "input": {
+                        "params": []
+                    }
+                }
+            },
+            "status": null,
+            "top": "30",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+            "group": null,
+            "uuid": "c90f8dec-ce4f-44e9-954b-ee1dda573f0a"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Compute Hash -> Create Indicator",
+            "targetStep": "\/api\/3\/workflow_steps\/7b8a17b1-0062-448b-9141-6a27ead0559c",
+            "sourceStep": "\/api\/3\/workflow_steps\/f8a65627-7b35-4c9d-ab23-8701aa426baa",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "cf9fa56b-ec1b-4954-b911-67d1f8699963"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Create FileHash MD5 Indicator -> Set Result",
+            "targetStep": "\/api\/3\/workflow_steps\/97f1bfb8-4bba-4e01-84dd-bd7c373da824",
+            "sourceStep": "\/api\/3\/workflow_steps\/a76eb49b-66c1-40e1-b4f9-cdf0bd51a47d",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "354df1da-ac81-4a93-b391-8e216824db7b"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Create File Indicator -> Copy of Create File Indicator",
+            "targetStep": "\/api\/3\/workflow_steps\/a76eb49b-66c1-40e1-b4f9-cdf0bd51a47d",
+            "sourceStep": "\/api\/3\/workflow_steps\/7b8a17b1-0062-448b-9141-6a27ead0559c",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "72be713d-ab04-4f09-874d-6383e6c4e64d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Excluded -> Compute Hash",
+            "targetStep": "\/api\/3\/workflow_steps\/f8a65627-7b35-4c9d-ab23-8701aa426baa",
+            "sourceStep": "\/api\/3\/workflow_steps\/b5d4b5cb-a1ec-41e0-90c6-6e7fc261154c",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e1176ab4-2c3d-4b33-b77a-84214de08b54"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Excluded -> No Ops",
+            "targetStep": "\/api\/3\/workflow_steps\/4b2c95e2-4e5a-43a0-8b2c-c7d883606a5f",
+            "sourceStep": "\/api\/3\/workflow_steps\/b5d4b5cb-a1ec-41e0-90c6-6e7fc261154c",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b9394401-cac6-46d6-9812-7df20bf51576"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Is Excluded",
+            "targetStep": "\/api\/3\/workflow_steps\/b5d4b5cb-a1ec-41e0-90c6-6e7fc261154c",
+            "sourceStep": "\/api\/3\/workflow_steps\/c90f8dec-ce4f-44e9-954b-ee1dda573f0a",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "018198dc-7151-44fb-a635-8a93edd4c754"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "uuid": "60544219-bf3c-4212-b5b7-a088060fd503",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "Referenced"
+    ]
+}

--- a/playbooks/03 - Enrich/Extract Indicators from Attachments.json
+++ b/playbooks/03 - Enrich/Extract Indicators from Attachments.json
@@ -33,7 +33,7 @@
             },
             "status": null,
             "top": "165",
-            "left": "475",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "417c69d3-6139-4c44-be56-f5d2ffbc3c43"
@@ -64,7 +64,7 @@
             },
             "status": null,
             "top": "1380",
-            "left": "650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "7e92f479-ab93-40b7-98a4-a37af6f6a2e9"
@@ -83,7 +83,7 @@
             },
             "status": null,
             "top": "570",
-            "left": "300",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "c48b363d-9bb6-4845-9603-29926459e697"
@@ -95,7 +95,7 @@
             "arguments": {
                 "params": {
                     "data": "{{vars.item.data['extracted_text']}}",
-                    "whitelist": "{{vars.input.params['excluded_iocs']}}",
+                    "whitelist": "{{vars.input.params.excludedIndicators}}",
                     "case_sensitive": false,
                     "override_regex": false,
                     "private_whitelist": true
@@ -113,7 +113,7 @@
             },
             "status": null,
             "top": "1245",
-            "left": "650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "b82e7069-76f8-45cd-af8c-0a815b21c37b"
@@ -145,7 +145,7 @@
             },
             "status": null,
             "top": "570",
-            "left": "650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
             "uuid": "c039b9c1-a1e9-4d7a-8450-fdda9b568c4f"
@@ -177,7 +177,7 @@
             },
             "status": null,
             "top": "1110",
-            "left": "650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
             "uuid": "2707b519-7d26-4e58-a362-69a2adb7528a"
@@ -206,7 +206,7 @@
             },
             "status": null,
             "top": "300",
-            "left": "475",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "e09b9459-fdc2-4122-b88a-b5d796b6a733"
@@ -216,11 +216,11 @@
             "name": "Get Unified IOCs",
             "description": null,
             "arguments": {
-                "__unified_iocs": "{{vars.unified_iocs.extend(vars.steps.Extract_Indicators | json_query(\"[0].data.results\") | flatten(levels=1) | json_query(\"[?type != `File`]\"))}}\n\n{% if vars.input.params.createFileIOCs %}\n{{ vars.unified_iocs.extend(vars.steps.Create_File_IOCs | json_query(\"[].file_ioc_details\") | flatten(levels=1)) }}{% endif %}"
+                "__unified_iocs": "{{ vars.unified_iocs.extend(vars.steps.Extract_Indicators | json_query(\"[].data.results\") | flatten(levels=1) | json_query(\"[?type != `File`]\") | unique) }}\n\n{% if vars.input.params.createFileIOCs %}\n{{ vars.unified_iocs.extend(vars.steps.Create_File_IOCs | json_query(\"[].file_ioc_details\") | flatten(levels=1)) }}\n{% endif %}"
             },
             "status": null,
             "top": "1515",
-            "left": "650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "b08f44a6-1233-472d-bb08-add2d484591f"
@@ -247,7 +247,7 @@
             },
             "status": null,
             "top": "435",
-            "left": "475",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "8f60e32e-f350-40c0-b4d4-994aeffd7f00"
@@ -266,7 +266,7 @@
             },
             "status": null,
             "top": "840",
-            "left": "650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "261c9c56-6114-4a92-a675-494febb411ec"
@@ -280,7 +280,7 @@
             },
             "status": null,
             "top": "1650",
-            "left": "650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "3e6f197c-a4b8-4f2f-8ee1-54d63d60b3ea"
@@ -298,7 +298,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "475",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
             "uuid": "e7f619d4-4ab0-4346-b128-16eed7861ca1"
@@ -326,7 +326,7 @@
             },
             "status": null,
             "top": "705",
-            "left": "650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "58d6e0d9-7635-4813-899f-e9e4de7c6f0b"
@@ -354,7 +354,7 @@
             },
             "status": null,
             "top": "975",
-            "left": "650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "941469e1-ba89-4770-9d7d-4c42e1491c75"

--- a/playbooks/03 - Enrich/Extract Indicators from Attachments.json
+++ b/playbooks/03 - Enrich/Extract Indicators from Attachments.json
@@ -10,8 +10,12 @@
     "singleRecordExecution": false,
     "remoteExecutableFlag": false,
     "parameters": [
-        "Alert ID",
-        "excluded_iocs"
+        "alertID",
+        "excludedIndicators",
+        "alertIRI",
+        "excludedFileIOCs",
+        "tenantIRI",
+        "createFileIOCs"
     ],
     "synchronous": false,
     "collection": "\/api\/3\/workflow_collections\/deaa4d19-7444-4f3a-a80e-9577436f25ef",
@@ -29,10 +33,41 @@
             },
             "status": null,
             "top": "165",
-            "left": "300",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "417c69d3-6139-4c44-be56-f5d2ffbc3c43"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create File IOCs",
+            "description": null,
+            "arguments": {
+                "when": "{{vars.input.params.createFileIOCs}}",
+                "for_each": {
+                    "item": "{{vars.steps.Find_Related_Attachments}}",
+                    "__bulk": false,
+                    "parallel": false,
+                    "condition": "{{(vars.item.file.filename not in vars.input.params.excludedFileIOCs) or (\".\" + vars.item.file.filename.split('.')[-1] not in vars.input.params.excludedFileIOCs)}}"
+                },
+                "arguments": {
+                    "fileIRI": "{{vars.item.file['@id']}}",
+                    "alertIRI": "{{vars.input.params.alertIRI}}",
+                    "tenantIRI": "{{vars.input.params.tenantIRI}}",
+                    "isExcluded": "{% if (vars.item.file.filename in vars.input.params.excludedFileIOCs) or (\".\" + vars.item.file.filename.split('.')[-1] in vars.input.params.excludedFileIOCs) %}true{% else %}false{% endif %}"
+                },
+                "apply_async": false,
+                "step_variables": [],
+                "pass_parent_env": false,
+                "pass_input_record": false,
+                "workflowReference": "\/api\/3\/workflows\/60544219-bf3c-4212-b5b7-a088060fd503"
+            },
+            "status": null,
+            "top": "1380",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "7e92f479-ab93-40b7-98a4-a37af6f6a2e9"
         },
         {
             "@type": "WorkflowStep",
@@ -48,7 +83,7 @@
             },
             "status": null,
             "top": "570",
-            "left": "125",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "c48b363d-9bb6-4845-9603-29926459e697"
@@ -65,7 +100,7 @@
                     "override_regex": false,
                     "private_whitelist": true
                 },
-                "version": "3.2.3",
+                "version": "3.2.4",
                 "for_each": {
                     "item": "{{vars.extracted_text}}",
                     "parallel": false,
@@ -78,7 +113,7 @@
             },
             "status": null,
             "top": "1245",
-            "left": "475",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "b82e7069-76f8-45cd-af8c-0a815b21c37b"
@@ -110,7 +145,7 @@
             },
             "status": null,
             "top": "570",
-            "left": "475",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
             "uuid": "c039b9c1-a1e9-4d7a-8450-fdda9b568c4f"
@@ -142,7 +177,7 @@
             },
             "status": null,
             "top": "1110",
-            "left": "475",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
             "uuid": "2707b519-7d26-4e58-a362-69a2adb7528a"
@@ -160,7 +195,7 @@
                         {
                             "type": "primitive",
                             "field": "alerts.id",
-                            "value": "{{vars.input.params['Alert ID']}}",
+                            "value": "{{vars.input.params.alertID}}",
                             "operator": "eq",
                             "_operator": "eq"
                         }
@@ -171,10 +206,24 @@
             },
             "status": null,
             "top": "300",
-            "left": "300",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "e09b9459-fdc2-4122-b88a-b5d796b6a733"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Unified IOCs",
+            "description": null,
+            "arguments": {
+                "__unified_iocs": "{{vars.unified_iocs.extend(vars.steps.Extract_Indicators | json_query(\"[0].data.results\") | flatten(levels=1) | json_query(\"[?type != `File`]\"))}}\n\n{% if vars.input.params.createFileIOCs %}\n{{ vars.unified_iocs.extend(vars.steps.Create_File_IOCs | json_query(\"[].file_ioc_details\") | flatten(levels=1)) }}{% endif %}"
+            },
+            "status": null,
+            "top": "1515",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "b08f44a6-1233-472d-bb08-add2d484591f"
         },
         {
             "@type": "WorkflowStep",
@@ -198,7 +247,7 @@
             },
             "status": null,
             "top": "435",
-            "left": "300",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "8f60e32e-f350-40c0-b4d4-994aeffd7f00"
@@ -213,11 +262,11 @@
                     "parallel": false,
                     "condition": ""
                 },
-                "__set_file_for_etraction": "{{vars.file_names_to_extract.extend(vars.item.data.filenames)}}"
+                "__set_file_for_extraction": "{{vars.file_names_to_extract.extend(vars.item.data.filenames)}}"
             },
             "status": null,
             "top": "840",
-            "left": "475",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "261c9c56-6114-4a92-a675-494febb411ec"
@@ -227,11 +276,11 @@
             "name": "Set Result",
             "description": null,
             "arguments": {
-                "attachment_indicators": "{{vars.steps.Extract_Indicators | json_query(\"[0].data.results\") | flatten(levels=1)}}"
+                "attachment_indicators": "{{vars.unified_iocs | unique }}"
             },
             "status": null,
-            "top": "1380",
-            "left": "475",
+            "top": "1650",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "3e6f197c-a4b8-4f2f-8ee1-54d63d60b3ea"
@@ -249,7 +298,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "300",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
             "uuid": "e7f619d4-4ab0-4346-b128-16eed7861ca1"
@@ -277,7 +326,7 @@
             },
             "status": null,
             "top": "705",
-            "left": "475",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "58d6e0d9-7635-4813-899f-e9e4de7c6f0b"
@@ -305,7 +354,7 @@
             },
             "status": null,
             "top": "975",
-            "left": "475",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "941469e1-ba89-4770-9d7d-4c42e1491c75"
@@ -324,13 +373,23 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Extract Indicators -> Format Extracted Data",
-            "targetStep": "\/api\/3\/workflow_steps\/3e6f197c-a4b8-4f2f-8ee1-54d63d60b3ea",
+            "name": "Create File IOCs -> Get Unified IOCs",
+            "targetStep": "\/api\/3\/workflow_steps\/b08f44a6-1233-472d-bb08-add2d484591f",
+            "sourceStep": "\/api\/3\/workflow_steps\/7e92f479-ab93-40b7-98a4-a37af6f6a2e9",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "938dc21a-eaa1-4be3-b6a2-0f8239d56ba6"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Extract Indicators -> Create File IOCs",
+            "targetStep": "\/api\/3\/workflow_steps\/7e92f479-ab93-40b7-98a4-a37af6f6a2e9",
             "sourceStep": "\/api\/3\/workflow_steps\/b82e7069-76f8-45cd-af8c-0a815b21c37b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "adab2fa0-ffdb-4a95-9d9e-0d1a138b7484"
+            "uuid": "54a206c0-dc86-4e07-8af3-367bbdfa0b02"
         },
         {
             "@type": "WorkflowRoute",
@@ -361,6 +420,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "4473cb84-8911-4c93-9a2b-aaacdfb08fd8"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Unified IOCs -> Set Result",
+            "targetStep": "\/api\/3\/workflow_steps\/3e6f197c-a4b8-4f2f-8ee1-54d63d60b3ea",
+            "sourceStep": "\/api\/3\/workflow_steps\/b08f44a6-1233-472d-bb08-add2d484591f",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ee2a5197-b729-499c-8eb3-c08d2513cdf7"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/03 - Enrich/Extract Indicators.json
+++ b/playbooks/03 - Enrich/Extract Indicators.json
@@ -124,7 +124,7 @@
                 "unified_iocs": "[]",
                 "alert_metadata": "{{vars.input.params.alertMetaData | ternary(vars.input.params.alertMetaData,vars.input.records[0])}}",
                 "alert_field_iocs": "[]",
-                "create_file_iocs": "true",
+                "create_file_iocs": "false",
                 "excluded_file_iocs": "{{(globalVars.Excludelist_Files | replace(\"*\", \"\") | replace(\" \", \"\")).split(\",\")}}",
                 "indicator_type_map": "{{globalVars.Indicator_Type_Map}}",
                 "excluded_indicators": "{{vars.ips | union(vars.domains) | union(vars.urls) | map('lower') | list}}"

--- a/playbooks/03 - Enrich/Extract Indicators.json
+++ b/playbooks/03 - Enrich/Extract Indicators.json
@@ -60,7 +60,7 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Extract Indicators from description",
+            "name": "Extract Indicators from Description",
             "description": "This is step is specifically designed for 'Suspicious Email' Alert",
             "arguments": {
                 "name": "CyOps Utilities",
@@ -72,12 +72,12 @@
                     "override_regex": "",
                     "private_whitelist": ""
                 },
-                "version": "3.2.0",
+                "version": "3.2.4",
                 "connector": "cyops_utilities",
                 "operation": "extract_artifacts",
                 "operationTitle": "CyOPs: Extract Artifacts from string",
                 "step_variables": {
-                    "description_iocs": "{{vars.result.data.results}}"
+                    "description_iocs": "{{vars.result.data.results | json_query(\"[?type != `File`]\")}}"
                 },
                 "operationOutput": []
             },
@@ -124,6 +124,8 @@
                 "unified_iocs": "[]",
                 "alert_metadata": "{{vars.input.params.alertMetaData | ternary(vars.input.params.alertMetaData,vars.input.records[0])}}",
                 "alert_field_iocs": "[]",
+                "create_file_iocs": "true",
+                "excluded_file_iocs": "{{(globalVars.Excludelist_Files | replace(\"*\", \"\") | replace(\" \", \"\")).split(\",\")}}",
                 "indicator_type_map": "{{globalVars.Indicator_Type_Map}}",
                 "excluded_indicators": "{{vars.ips | union(vars.domains) | union(vars.urls) | map('lower') | list}}"
             },
@@ -136,7 +138,7 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Extract Indicators from body",
+            "name": "Extract Indicators from Body",
             "description": "This is step is specifically designed for 'Suspicious Email' Alert",
             "arguments": {
                 "name": "CyOps Utilities",
@@ -148,12 +150,12 @@
                     "override_regex": "",
                     "private_whitelist": ""
                 },
-                "version": "3.0.3",
+                "version": "3.2.4",
                 "connector": "cyops_utilities",
                 "operation": "extract_artifacts",
                 "operationTitle": "CyOPs: Extract Artifacts from string",
                 "step_variables": {
-                    "email_body_iocs": "{{vars.result.data.results}}"
+                    "email_body_iocs": "{{vars.result.data.results | json_query(\"[?type != `File`]\")}}"
                 },
                 "operationOutput": []
             },
@@ -280,7 +282,7 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Extract Indicators from header",
+            "name": "Extract Indicators from Header",
             "description": "This is step is specifically designed for 'Suspicious Email' Alert",
             "arguments": {
                 "name": "CyOps Utilities",
@@ -292,12 +294,12 @@
                     "override_regex": "",
                     "private_whitelist": ""
                 },
-                "version": "3.0.3",
+                "version": "3.2.4",
                 "connector": "cyops_utilities",
                 "operation": "extract_artifacts",
                 "operationTitle": "CyOPs: Extract Artifacts from string",
                 "step_variables": {
-                    "header_iocs": "{{vars.result.data.results}}"
+                    "header_iocs": "{{vars.result.data.results | json_query(\"[?type != `File`]\")}}"
                 },
                 "operationOutput": []
             },
@@ -313,7 +315,7 @@
             "name": "Update Indicator List",
             "description": null,
             "arguments": {
-                "temp": "{% for key,value in vars.indicator_type_map.items()%}\n    {%if vars.alert_metadata.get(key) %}\n        {% set list_vals = vars.alert_metadata.get(key) if vars.alert_metadata.get(key) | type_debug == 'list' else vars.alert_metadata.get(key).split(\",\") %}\n        {%for val in list_vals%}\n            {% set _val = val | regex_search('[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+') %}\n            {% if (_val == None) and (val|string|lower not in vars.excluded_indicators) %}\n                {{vars.alert_field_iocs.append({\"type\": value, \"value\":val})}}\n            {% elif (_val != None) and _val.split('@')[-1]|lower not in vars.excluded_indicators %}\n                {{vars.alert_field_iocs.append({\"type\": value, \"value\":_val})}}\n            {% endif %}\n        {%endfor%}\n    {%endif%}\n{%endfor%}"
+                "temp": "{% for key,value in vars.indicator_type_map.items()%}\n    {%if vars.alert_metadata.get(key) %}\n        {% set list_vals = vars.alert_metadata.get(key) if vars.alert_metadata.get(key) | type_debug == 'list' else vars.alert_metadata.get(key).split(\",\") %}\n        {%for val in list_vals%}\n            {% set _val = val | regex_search('[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+') %}\n            {% if (_val == None) and (val|string|lower not in vars.excluded_indicators) %}\n                {{vars.alert_field_iocs.append({\"type\": value, \"value\":val|replace(' ','')})}}\n            {% elif (_val != None) and _val.split('@')[-1]|lower not in vars.excluded_indicators %}\n                {{vars.alert_field_iocs.append({\"type\": value, \"value\":_val})}}\n            {% endif %}\n        {%endfor%}\n    {%endif%}\n{%endfor%}"
             },
             "status": null,
             "top": "435",
@@ -353,6 +355,7 @@
                             "value": "\/api\/3\/picklists\/501d0562-89a0-4079-9a9e-cdde7d34e3ed",
                             "_value": {
                                 "@id": "\/api\/3\/picklists\/501d0562-89a0-4079-9a9e-cdde7d34e3ed",
+                                "display": "Indicator Extracted",
                                 "itemValue": "Indicator Extracted"
                             },
                             "operator": "neq"
@@ -428,6 +431,7 @@
             "name": "Get Indicators",
             "description": null,
             "arguments": {
+                "temp": "",
                 "alert_field_iocs": "{{ vars.alert_field_iocs | json_query('[?value != null]') }}"
             },
             "status": null,
@@ -494,8 +498,12 @@
             "arguments": {
                 "when": "{{vars.input.records[0].type.itemValue in ['Suspicious Email', 'Phishing']}}",
                 "arguments": {
-                    "Alert ID": "{{vars.input.records[0].id}}",
-                    "excluded_iocs": "{{vars.excluded_indicators}}"
+                    "alertID": "{{vars.alert_metadata.id}}",
+                    "alertIRI": "{{vars.alert_iri}}",
+                    "tenantIRI": "{{vars.tenant_iri}}",
+                    "createFileIOCs": "{{vars.create_file_iocs}}",
+                    "excludedFileIOCs": "{{vars.excluded_file_iocs}}",
+                    "excludedIndicators": "{{vars.excluded_indicators}}"
                 },
                 "apply_async": false,
                 "step_variables": {
@@ -576,7 +584,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Extract Indicators from body -> Extract Indicators from description",
+            "name": "Extract Indicators from Body -> Extract Indicators from Description",
             "targetStep": "\/api\/3\/workflow_steps\/18f57e7b-c825-430a-9b86-fb1c8274b257",
             "sourceStep": "\/api\/3\/workflow_steps\/6ea0365a-3a12-495c-82d9-17c787bda75f",
             "label": null,
@@ -586,7 +594,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Extract Indicators from description -> Extract Attachment Indicators",
+            "name": "Extract Indicators from Description -> Extract Attachment Indicators",
             "targetStep": "\/api\/3\/workflow_steps\/a5b6f558-5b1a-4953-9c97-d83fd818bc3a",
             "sourceStep": "\/api\/3\/workflow_steps\/18f57e7b-c825-430a-9b86-fb1c8274b257",
             "label": null,
@@ -596,7 +604,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Extract Indicators from header -> Extract Indicators from body",
+            "name": "Extract Indicators from Header -> Extract Indicators from Body",
             "targetStep": "\/api\/3\/workflow_steps\/6ea0365a-3a12-495c-82d9-17c787bda75f",
             "sourceStep": "\/api\/3\/workflow_steps\/9394cafa-441a-4131-b328-bbd2e3339c12",
             "label": null,
@@ -606,7 +614,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Indicators -> Extract Indicators from header",
+            "name": "Get Indicators -> Extract Indicators from Header",
             "targetStep": "\/api\/3\/workflow_steps\/9394cafa-441a-4131-b328-bbd2e3339c12",
             "sourceStep": "\/api\/3\/workflow_steps\/e7bbfc81-c4c6-4768-a875-e24d81d30de5",
             "label": null,

--- a/playbooks/03 - Enrich/Get Unprocessed Indicators.json
+++ b/playbooks/03 - Enrich/Get Unprocessed Indicators.json
@@ -47,7 +47,7 @@
         {
             "@type": "WorkflowStep",
             "name": "Find Unenriched Indicators",
-            "description": "Retrieves \"In Process\" indicators created in the past 25 hours, excluding the last hour.",
+            "description": "Retrieve indicators with \"In Process\" Enrichment Status created in the past 25 hours, excluding the last hour.",
             "arguments": {
                 "query": {
                     "sort": [],

--- a/playbooks/globalVariables.json
+++ b/playbooks/globalVariables.json
@@ -106,5 +106,11 @@
         "name": "User_Enrichment_Playbooks_IRIs",
         "value": "NoEnrichmentAvailable",
         "default_value": "NoEnrichmentAvailable"
+    },
+    {
+        "id": 36,
+        "name": "Excludelist_Files",
+        "value": "",
+        "default_value": ""
     }
 ]


### PR DESCRIPTION

File IOC-related changes are mainly focused on `Suspicious Email` and `Phishing` type of alerts. Below UTCs are tested for the following types of mail

    - Email without attachment 
    - Email with attachment(zip/pdf)
    - Email with zip attachment (.zip contains eml file with attachment)
    - EML as attachment -> Eml contains no attachment 
    - EML as attachment -> Eml contains pdf attachment 
    - EML as attachment -> Eml contains zip attachment

### Mantis#0945354 - Exclude file indicator creation based on the filename or extension

- Added new global variable "Excludelist_Files" 
- Validated that file indicators matching the entries in the 'Excludelist_Files' global variable are correctly marked as excluded.

### Mantis#0945349 - File IOC DeDuplication Issue

- Validated that the file indicators are created with MD5 added in the indicator name e.g. "File - fileName - MD5"
- Validate that FileHash-MD5 type indicators are successfully created for corresponding File IOCs and linked accordingly.
- Validated that both File and FileHash IOCs are getting linked to the alert
- Validated that when choosing not to create, file IOCs are not generated as per the new provision. (a new variable `create_file_iocs` is introduced in _03 Enrich > Extract Indicators_ playbook)

