### PR TITLE
BugFixes-5

### DIFF
--- a/modules/assets/detail-layout.json
+++ b/modules/assets/detail-layout.json
@@ -123,6 +123,11 @@
                                                                                                         "name": "product",
                                                                                                         "highlightMode": true,
                                                                                                         "readOnly": false
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "name": "bESCyberAssetCategory",
+                                                                                                        "highlightMode": true,
+                                                                                                        "readOnly": true
                                                                                                     }
                                                                                                 ],
                                                                                                 "style": "col-lg-4"

--- a/modules/assets/mmd.json
+++ b/modules/assets/mmd.json
@@ -28,6 +28,106 @@
         {
             "@type": "AttributeMetadata",
             "type": "picklists",
+            "name": "bESCyberAssetCategory",
+            "length": null,
+            "orderIndex": 52,
+            "formType": "picklist",
+            "dataSource": {
+                "model": "picklists",
+                "query": {
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "listName__name",
+                            "operator": "eq",
+                            "value": "BES Cyber Asset Category"
+                        }
+                    ],
+                    "sort": [
+                        {
+                            "field": "orderIndex",
+                            "direction": "ASC"
+                        }
+                    ]
+                },
+                "displayConditions": {
+                    "807a51b8-ef06-4f0c-91be-ee99c6f649e9": {
+                        "visibility": "visible",
+                        "conditions": null
+                    },
+                    "c9093965-69b5-4bc4-90ba-d59e256a957e": {
+                        "visibility": "visible",
+                        "conditions": null
+                    },
+                    "740d017c-7c92-4e42-ac53-7fda17122722": {
+                        "visibility": "visible",
+                        "conditions": null
+                    },
+                    "f9145b90-6cae-4a6a-b5d9-0e0607982829": {
+                        "visibility": "visible",
+                        "conditions": null
+                    }
+                }
+            },
+            "searchable": false,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761,
+                "_enableRange": false
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonText": "",
+                "buttonIcon": "",
+                "buttonClass": "btn btn-default btn-sm"
+            },
+            "dataSourceFilters": null,
+            "defaultValue": null,
+            "tooltip": null,
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "bESCyberAssetCategory",
+                            "operator": "isnull",
+                            "value": "false",
+                            "_value": {
+                                "display": "",
+                                "itemValue": "",
+                                "@id": "false"
+                            },
+                            "type": "object"
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": null,
+            "readable": true,
+            "writeable": true,
+            "identifier": null,
+            "unique": false,
+            "recommend": false,
+            "skipSerialization": false,
+            "displayName": "{{ bESCyberAssetCategory }}",
+            "descriptions": {
+                "singular": "BES Cyber Asset Category"
+            }
+        },
+        {
+            "@type": "AttributeMetadata",
+            "type": "picklists",
             "name": "assetRisk",
             "length": null,
             "orderIndex": 1,

--- a/picklists/BES Cyber Asset Category.json
+++ b/picklists/BES Cyber Asset Category.json
@@ -1,0 +1,50 @@
+{
+    "@context": "\/api\/3\/contexts\/PicklistName",
+    "@id": "\/api\/3\/picklist_names\/8b167004-257b-407c-86f7-ee65059176b0",
+    "@type": "PicklistName",
+    "name": "BES Cyber Asset Category",
+    "system": false,
+    "picklists": [
+        {
+            "@id": "\/api\/3\/picklists\/807a51b8-ef06-4f0c-91be-ee99c6f649e9",
+            "@type": "Picklist",
+            "itemValue": "Protected Cyber Asset",
+            "orderIndex": 0,
+            "color": null,
+            "icon": null,
+            "listName": "\/api\/3\/picklist_names\/8b167004-257b-407c-86f7-ee65059176b0",
+            "uuid": "807a51b8-ef06-4f0c-91be-ee99c6f649e9"
+        },
+        {
+            "@id": "\/api\/3\/picklists\/c9093965-69b5-4bc4-90ba-d59e256a957e",
+            "@type": "Picklist",
+            "itemValue": "Electronic Access Control or Monitoring Systems",
+            "orderIndex": 1,
+            "color": null,
+            "icon": null,
+            "listName": "\/api\/3\/picklist_names\/8b167004-257b-407c-86f7-ee65059176b0",
+            "uuid": "c9093965-69b5-4bc4-90ba-d59e256a957e"
+        },
+        {
+            "@id": "\/api\/3\/picklists\/740d017c-7c92-4e42-ac53-7fda17122722",
+            "@type": "Picklist",
+            "itemValue": "Physical Access Control Systems",
+            "orderIndex": 2,
+            "color": null,
+            "icon": null,
+            "listName": "\/api\/3\/picklist_names\/8b167004-257b-407c-86f7-ee65059176b0",
+            "uuid": "740d017c-7c92-4e42-ac53-7fda17122722"
+        },
+        {
+            "@id": "\/api\/3\/picklists\/f9145b90-6cae-4a6a-b5d9-0e0607982829",
+            "@type": "Picklist",
+            "itemValue": "Transient Cyber Asset",
+            "orderIndex": 3,
+            "color": null,
+            "icon": null,
+            "listName": "\/api\/3\/picklist_names\/8b167004-257b-407c-86f7-ee65059176b0",
+            "uuid": "f9145b90-6cae-4a6a-b5d9-0e0607982829"
+        }
+    ],
+    "uuid": "8b167004-257b-407c-86f7-ee65059176b0"
+}

--- a/playbooks/03 - Enrich/Enrich Indicators (Type All).json
+++ b/playbooks/03 - Enrich/Enrich Indicators (Type All).json
@@ -633,7 +633,6 @@
             "arguments": {
                 "when": "{{not vars.input.params['indicator_value'] == None}}",
                 "resource": {
-                    "indicatorStatus": "{% if vars.indicator_type == 'File' and 'Excluded' in (vars.indicator_iri | fromIRI).recordTags %}{{\"IndicatorStatus\" | picklist(\"Excluded\", \"@id\")}}{% else %}{{\"IndicatorStatus\" | picklist(\"TBD\", \"@id\")}}{% endif %}",
                     "enrichmentStatus": "\/api\/3\/picklists\/8a4609d2-8a3d-4bda-9888-5f00bfea43cb"
                 },
                 "_showJson": false,

--- a/playbooks/03 - Enrich/Extract Indicators - Create File Indicator.json
+++ b/playbooks/03 - Enrich/Extract Indicators - Create File Indicator.json
@@ -108,7 +108,7 @@
                     "filehashSHA1": "{{vars.steps.Compute_Hash.data.sha1}}",
                     "expiredStatus": "\/api\/3\/picklists\/d4ca4a72-7974-4b93-843e-da9efa235c6e",
                     "filehashSHA256": "{{vars.steps.Compute_Hash.data.sha256}}",
-                    "indicatorStatus": "\/api\/3\/picklists\/2f5cff61-fbff-4bb3-96be-302b78a9fb47",
+                    "indicatorStatus": "{% if vars.input.params.isExcluded %}{{\"IndicatorStatus\" | picklist(\"Excluded\", \"@id\")}}{% else %}{{\"IndicatorStatus\" | picklist(\"TBD\", \"@id\")}}{% endif %}",
                     "typeofindicator": "\/api\/3\/picklists\/0162241b-f5bf-4917-a150-00e920be47bd",
                     "__fieldsToUpdate": [
                         "lastSeen",

--- a/playbooks/03 - Enrich/Extract Indicators.json
+++ b/playbooks/03 - Enrich/Extract Indicators.json
@@ -124,7 +124,7 @@
                 "unified_iocs": "[]",
                 "alert_metadata": "{{vars.input.params.alertMetaData | ternary(vars.input.params.alertMetaData,vars.input.records[0])}}",
                 "alert_field_iocs": "[]",
-                "create_file_iocs": "false",
+                "create_file_iocs": "true",
                 "excluded_file_iocs": "{{(globalVars.Excludelist_Files | replace(\"*\", \"\") | replace(\" \", \"\")).split(\",\")}}",
                 "indicator_type_map": "{{globalVars.Indicator_Type_Map}}",
                 "excluded_indicators": "{{vars.ips | union(vars.domains) | union(vars.urls) | map('lower') | list}}"
@@ -246,6 +246,7 @@
                                 "value": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
                                 "_value": {
                                     "@id": "\/api\/3\/picklists\/ae98ebc6-beef-4882-9980-1d88fc6d87cd",
+                                    "display": "TBD",
                                     "itemValue": "TBD"
                                 },
                                 "operator": "neq"
@@ -269,7 +270,7 @@
                 },
                 "for_each": {
                     "item": "{{vars.steps.Create_Indicator}}",
-                    "condition": "{{vars.item.enrichmentStatus.itemValue != \"Completed\"}}"
+                    "condition": "{{vars.item.enrichmentStatus.itemValue != \"Completed\" and vars.item.indicatorStatus.itemValue != \"Excluded\"}}"
                 },
                 "step_variables": []
             },


### PR DESCRIPTION
As discussed changes in #188, made changes in the file IOC creation flow

### Mantis#0945349 - File IOC DeDuplication Issue
- File IOC creation is now enabled by default.
- Updated the wait condition in the '03 - Enrich > Extract Indicators' playbook. Now, excluded file IOCs will be created and marked as excluded, but no enrichment will occur for them.

### Mantis#0953192 - New fields and SVT changes in Asset Module related to SP-NERC CIP 002
- Added 
   - New Field -> BES Cyber Asset Category
   - New picklist -> BES Cyber Asset Category
   - Made relevant changes in the Asset Detailed View
