### PR TITLE
QA-BugFixes-2

### DIFF
--- a/info.json
+++ b/info.json
@@ -427,8 +427,8 @@
             {
                 "id": 13,
                 "name": "Excludelist_Domains",
-                "value": "google.com,yahoo.com,fortinet.net,cybersponse.com,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com,w3.org",
-                "default_value": "google.com,yahoo.com,fortinet.net,cybersponse.com,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com,w3.org"
+                "value": "google.com,yahoo.com,fortinet.net,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com,w3.org",
+                "default_value": "google.com,yahoo.com,fortinet.net,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com,w3.org"
             },
             {
                 "id": 15,

--- a/modules/alerts/detail-layout.json
+++ b/modules/alerts/detail-layout.json
@@ -809,10 +809,6 @@
                                                                                         "name": "escalationReason"
                                                                                     },
                                                                                     {
-                                                                                        "title": "Source Type",
-                                                                                        "name": "sourceType"
-                                                                                    },
-                                                                                    {
                                                                                         "title": "Detection Date",
                                                                                         "name": "alertDetectionDate"
                                                                                     },

--- a/playbooks/globalVariables.json
+++ b/playbooks/globalVariables.json
@@ -50,8 +50,8 @@
     {
         "id": 13,
         "name": "Excludelist_Domains",
-        "value": "google.com,yahoo.com,fortinet.net,cybersponse.com,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com,w3.org",
-        "default_value": "google.com,yahoo.com,fortinet.net,cybersponse.com,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com,w3.org"
+        "value": "google.com,yahoo.com,fortinet.net,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com,w3.org",
+        "default_value": "google.com,yahoo.com,fortinet.net,gmail.com,outlook.com,microsoft.com,fortinet.com,twitter.com,facebook.com,linkedin.com,instagram.com,fortiguard.com,forticloud.com,w3.org"
     },
     {
         "id": 15,


### PR DESCRIPTION
### Mantis#0909761
- Remove `Source Type` from the exclude list configuration of the `Fields of Interest` widget

### Modified `Excludelist_Domains`
- Removed `cybersponse.com` from `Excludelist_Domains` global variable