### PR TITLE
BugFixes-6

### DIFF
--- a/modules/alerts/detail-layout.json
+++ b/modules/alerts/detail-layout.json
@@ -913,7 +913,7 @@
                                                                                         "name": "ticketID"
                                                                                     }
                                                                                 ],
-                                                                                "hideEmptyFields": false,
+                                                                                "hideEmptyFields": true,
                                                                                 "includeAll": true,
                                                                                 "allReadOnly": true,
                                                                                 "allHighlightMode": true,


### PR DESCRIPTION
### Mantis#1004200
- Validated that the "Hide Empty Fields" checkbox is checked by default in Alert MMD