### PR TITLE
BugFixes-4

### DIFF
--- a/modules/incidents/detail-layout.json
+++ b/modules/incidents/detail-layout.json
@@ -65,11 +65,31 @@
                                                                                 },
                                                                                 "picklistItem": "state"
                                                                             }
+                                                                        },
+                                                                        {
+                                                                            "type": "customPicklistMessage-1.1.2",
+                                                                            "config": {
+                                                                                "wid": "b378d991-3b11-4e12-a029-74de6340ceeb",
+                                                                                "picklits_mapping": {
+                                                                                    "options": [
+                                                                                        {
+                                                                                            "picklistValue": "Resolved",
+                                                                                            "picklistLoadingTitle": "Incident is Resolved.",
+                                                                                            "showIcon": true,
+                                                                                            "picklistMessageIcon": "icon icon-resolve",
+                                                                                            "showSpinner": false
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "picklistItem": "status"
+                                                                            }
                                                                         }
-                                                                    ]
+                                                                    ],
+                                                                    "style": "col-lg-12"
                                                                 }
                                                             ],
-                                                            "wid": "7714071f-77a8-49af-a141-c6ac0451b619"
+                                                            "wid": "7714071f-77a8-49af-a141-c6ac0451b619",
+                                                            "_collapsed": false
                                                         },
                                                         {
                                                             "columns": [

--- a/playbooks/06 - IRP - Communications Tracking/Manual Send Notification.json
+++ b/playbooks/06 - IRP - Communications Tracking/Manual Send Notification.json
@@ -20,7 +20,6 @@
             "name": "Configuration",
             "description": null,
             "arguments": {
-                "reply-to": "{{globalVars.Default_Email}}",
                 "attachments": "{%set attach= [ ] %}{% if vars.input.records[0].file %}{%set _tmp=attach.append(vars.input.records[0].file['@id'])%}{%endif%}{{attach}}",
                 "use_exchange_connector": "true"
             },
@@ -183,7 +182,7 @@
                 "params": {
                     "iri": "\/api\/integration\/connectors\/{{vars.connector_name}}\/{{vars.connector_version}}\/",
                     "body": "",
-                    "method": "GET"
+                    "method": "POST"
                 },
                 "version": "3.0.4",
                 "connector": "cyops_utilities",

--- a/playbooks/06 - IRP - Communications Tracking/Send Notification.json
+++ b/playbooks/06 - IRP - Communications Tracking/Send Notification.json
@@ -130,7 +130,6 @@
             "name": "Configuration",
             "description": null,
             "arguments": {
-                "reply-to": "{{globalVars.Default_Email}}",
                 "emailBody": "{{vars.steps.Convert_Markdown_Email_Body_to_HTML.data.html}}",
                 "attachments": "{%set attach= [ ] %}{% if vars.input.records[0].file %}{%set _tmp=attach.append(vars.input.records[0].file['@id'])%}{%endif%}{{attach}}",
                 "use_exchange_connector": "true"

--- a/playbooks/08 - Utilities/Incident - Record Closure Validation.json
+++ b/playbooks/08 - Utilities/Incident - Record Closure Validation.json
@@ -22,6 +22,7 @@
             "arguments": {
                 "incidentID": "{{vars.input.records[0].id}}",
                 "incidentIRI": "{{vars.input.records[0]['@id']}}",
+                "incidentName": "{{vars.input.records[0].name}}",
                 "previousStatus": "{{vars.previous.data.status}}"
             },
             "status": null,
@@ -36,8 +37,8 @@
             "name": "Create Comment Content",
             "description": null,
             "arguments": {
-                "commentContent": "Found <strong>\"Incident#{{vars.incidentID}} - {{vars.incidentName}}\"<\/strong> closed without completing its associated {% if vars.pendingManualInputsFound and vars.pendingTasksFound %}tasks and manual inputs.{% elif vars.pendingTasksFound%}tasks.{% elif vars.pendingManualInputsFound %}manual inputs.{% endif %}\n<p>&nbsp;<\/p>\n{% if vars.pendingTasksFound %}\nReview below incomplete tasks:\n{% for item in vars.steps.Get_Pending_Tasks[0].tasks %}{% if item.status != (\"TaskStatus\" | picklist(\"Completed\", \"@id\")) %}<a href=\"\/modules\/view-panel\/tasks\/{{item.uuid}}\" target=\"_blank\" rel=\"noopener\">Task#{{item.id}} - {{item.name}}<\/a><br>{% endif %}{% endfor %}\n<p>&nbsp;<\/p>\n{% endif %}",
-                "pendingItemsClosureComment": "{% if vars.pendingTasksFound and vars.pendingManualInputsFound %}Pending manual inputs and following tasks{% elif vars.pendingTasksFound%}Following pending tasks{% elif vars.pendingManualInputsFound %}Pending manual inputs{% endif %} associated with this incident has been closed.\n{% if vars.pendingTasksFound %}\n<h6>Tasks:<\/h6>\n{% for item in vars.steps.Get_Pending_Tasks[0].tasks %}{% if item.status != (\"TaskStatus\" | picklist(\"Completed\", \"@id\")) %}<a href=\"\/modules\/view-panel\/tasks\/{{item.uuid}}\" target=\"_blank\" rel=\"noopener\">Task#{{item.id}} - {{item.name}}<\/a><br>{% endif %}{% endfor %}\n{% endif %}\n<p>&nbsp;<\/p>"
+                "commentContent": "Found <strong>\"Incident#{{vars.incidentID}} - {{vars.incidentName}}\"<\/strong> closed without completing its associated {% if vars.pendingManualInputsFound and vars.pendingTasksFound %}tasks and manual inputs.{% elif vars.pendingTasksFound%}tasks.{% elif vars.pendingManualInputsFound %}manual inputs.{% endif %}\n<p>&nbsp;<\/p>\n{% if vars.pendingTasksFound %}\nReview below incomplete tasks:\n{% for item in vars.steps.Get_Pending_Tasks %}{% if item.status != (\"TaskStatus\" | picklist(\"Completed\", \"@id\")) %}<a href=\"\/modules\/view-panel\/tasks\/{{item.uuid}}\" target=\"_blank\" rel=\"noopener\">Task#{{item.id}} - {{item.name}}<\/a><br>{% endif %}{% endfor %}\n<p>&nbsp;<\/p>\n{% endif %}",
+                "pendingItemsClosureComment": "{% if vars.pendingTasksFound and vars.pendingManualInputsFound %}Pending manual inputs and following tasks{% elif vars.pendingTasksFound%}Following pending tasks{% elif vars.pendingManualInputsFound %}Pending manual inputs{% endif %} associated with this incident has been closed.\n{% if vars.pendingTasksFound %}\n<h6>Tasks:<\/h6>\n{% for item in vars.steps.Get_Pending_Tasks %}{% if item.status != (\"TaskStatus\" | picklist(\"Completed\", \"@id\")) %}<a href=\"\/modules\/view-panel\/tasks\/{{item.uuid}}\" target=\"_blank\" rel=\"noopener\">Task#{{item.id}} - {{item.name}}<\/a><br>{% endif %}{% endfor %}\n{% endif %}\n<p>&nbsp;<\/p>"
             },
             "status": null,
             "top": "705",
@@ -160,18 +161,22 @@
                     "logic": "AND",
                     "filters": [
                         {
-                            "type": "primitive",
-                            "field": "id",
-                            "value": "{{vars.incidentID}}",
-                            "operator": "eq",
-                            "_operator": "eq"
-                        },
-                        {
                             "logic": "OR",
                             "filters": [
                                 {
                                     "type": "object",
-                                    "field": "tasks.status",
+                                    "field": "status",
+                                    "value": "true",
+                                    "_value": {
+                                        "@id": "true",
+                                        "display": "",
+                                        "itemValue": ""
+                                    },
+                                    "operator": "isnull"
+                                },
+                                {
+                                    "type": "object",
+                                    "field": "status",
                                     "value": "\/api\/3\/picklists\/343f4b67-e929-4205-bf95-ba5b70545fed",
                                     "_value": {
                                         "@id": "\/api\/3\/picklists\/343f4b67-e929-4205-bf95-ba5b70545fed",
@@ -179,23 +184,24 @@
                                         "itemValue": "Completed"
                                     },
                                     "operator": "neq"
-                                },
-                                {
-                                    "type": "object",
-                                    "field": "tasks.status",
-                                    "value": "null",
-                                    "_value": {
-                                        "@id": "null",
-                                        "display": "",
-                                        "itemValue": ""
-                                    },
-                                    "operator": "isnull"
                                 }
                             ]
+                        },
+                        {
+                            "type": "primitive",
+                            "field": "incidents.id",
+                            "value": "{{vars.incidentID}}",
+                            "operator": "eq",
+                            "_operator": "eq"
                         }
+                    ],
+                    "__selectFields": [
+                        "name",
+                        "status",
+                        "incidents"
                     ]
                 },
-                "module": "incidents?$limit=30&$relationships=true&$fsr_max_relation_count=100",
+                "module": "tasks?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
                     "pendingTasksFound": "{% if vars.steps.Get_Pending_Tasks | length > 0 %}true{% else %}false{% endif %}"
@@ -206,7 +212,7 @@
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
-            "uuid": "d76e618f-f9f3-45fe-8258-e5fc7c225afa"
+            "uuid": "afe25df8-9593-42ea-a556-ec2988a1c86f"
         },
         {
             "@type": "WorkflowStep",
@@ -277,7 +283,7 @@
             "arguments": {
                 "when": "{{vars.pendingTasksFound}}",
                 "for_each": {
-                    "item": "{{vars.steps.Get_Pending_Tasks[0].tasks}}",
+                    "item": "{{vars.steps.Get_Pending_Tasks}}",
                     "__bulk": true,
                     "parallel": false,
                     "condition": "",
@@ -286,7 +292,7 @@
                 "resource": {
                     "status": "\/api\/3\/picklists\/343f4b67-e929-4205-bf95-ba5b70545fed"
                 },
-                "_showJson": false,
+                "_showJson": true,
                 "operation": "Append",
                 "collection": "{{vars.item['@id']}}",
                 "__recommend": [],
@@ -527,22 +533,22 @@
         {
             "@type": "WorkflowRoute",
             "name": "Get Pending Manual Inputs -> Get Pending Tasks",
-            "targetStep": "\/api\/3\/workflow_steps\/d76e618f-f9f3-45fe-8258-e5fc7c225afa",
+            "targetStep": "\/api\/3\/workflow_steps\/afe25df8-9593-42ea-a556-ec2988a1c86f",
             "sourceStep": "\/api\/3\/workflow_steps\/54cb3c6d-7ac6-4396-90c1-c2720e50319a",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "caf1762b-a4a1-4f40-9b58-6730fffa92bb"
+            "uuid": "e29f0a51-d133-4b84-9043-b2427c393a68"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Pending Tasks -> Any Pending Items Present",
+            "name": "Get Pending Tasks -> Found Pending Items",
             "targetStep": "\/api\/3\/workflow_steps\/556bcdb9-61fb-4b1f-aa2b-e5f8ae466629",
-            "sourceStep": "\/api\/3\/workflow_steps\/d76e618f-f9f3-45fe-8258-e5fc7c225afa",
+            "sourceStep": "\/api\/3\/workflow_steps\/afe25df8-9593-42ea-a556-ec2988a1c86f",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "c19469b9-cc50-437d-b9d4-aa63816b48be"
+            "uuid": "ee6d039a-2fe5-4d02-b8f0-da716e160af5"
         },
         {
             "@type": "WorkflowRoute",


### PR DESCRIPTION
### Mantis#1034029
- Validated that the 'Incident - Record Closure Validation' playbook doesn't trigger incorrectly when closing an incident without linked tasks.

### Mantis#1012902

- Removed unused variable "reply-to" from:
  - 06 - IRP - Communications Tracking > Manual Send Notification
  - 06 - IRP - Communications Tracking > Send Notification
- Validated "Get From Email Id" in "Manual Send Notification" playbook uses the 'POST' method instead of 'GET'