### PR TITLE
Removed Widget Launch Setting

### DIFF
--- a/info.json
+++ b/info.json
@@ -21,18 +21,6 @@
     "supportInfo": "Fortinet Customer Support",
     "iconLarge": null,
     "fsrMinCompatibility": "7.6.0",
-    "postInstallConfig": {
-        "enabled": true,
-        "widgets": [
-            {
-                "name": "soarFrameworkConfigurationWizard",
-                "label": "SOAR Framework Configuration Wizard",
-                "version": "1.0.0",
-                "buttonLabel": "Configure",
-                "autoLaunch": true
-            }
-        ]
-    },
     "date": "2024-06-04T15:15:46+00:00",
     "contents": {
         "picklistNames": [


### PR DESCRIPTION
### Mantis#1051865 
- Validated that "SFSP Wizard" launch button has been removed from the SFSP