### PR TITLE
BugFixes-16

### DIFF
--- a/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (Referenced).json
+++ b/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident (Referenced).json
@@ -1,5 +1,4 @@
 {
-    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "Alert - Escalate To Incident (Referenced)",
@@ -327,7 +326,7 @@
                                 "tooltip": "",
                                 "dataType": "checkbox",
                                 "formType": "checkbox",
-                                "required": true,
+                                "required": false,
                                 "_expanded": false,
                                 "mmdUpdate": true,
                                 "collection": false,
@@ -447,7 +446,7 @@
                                 "dataType": "text",
                                 "formType": "text",
                                 "required": true,
-                                "_expanded": true,
+                                "_expanded": false,
                                 "defaultValue": null,
                                 "_previousName": "closure",
                                 "visibilityQuery": {

--- a/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident.json
+++ b/playbooks/06 - IRP - Case Management/Alert - Escalate To Incident.json
@@ -480,7 +480,7 @@
                         "tooltip": "Select this option to close all selected alerts upon incident escalation.",
                         "dataType": "checkbox",
                         "formType": "checkbox",
-                        "required": true,
+                        "required": false,
                         "_expanded": false,
                         "mmdUpdate": true,
                         "collection": false,


### PR DESCRIPTION
### Mantis#1056631
- Validated that the "Close Alert" checkbox is not marked as mandatory in Alert escalation playbook