### PR TITLE
Release/3.1.0

### DIFF
--- a/info.json
+++ b/info.json
@@ -717,7 +717,7 @@
             {
                 "name": "Key Store",
                 "apiName": "keys",
-                "count": 6
+                "count": 2
             }
         ],
         "preprocessingRules": [

--- a/postInstall/execution_list.json
+++ b/postInstall/execution_list.json
@@ -1,0 +1,3 @@
+{
+    "execution_sequence":["936f4403-593d-4d5a-a5ad-b8d04b4cbd3c"]
+}

--- a/postInstall/workflow/Excluded Indicators Migration > Fetch Migration Data.json
+++ b/postInstall/workflow/Excluded Indicators Migration > Fetch Migration Data.json
@@ -1,0 +1,295 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Excluded Indicators Migration > Fetch Migration Data",
+    "aliasName": null,
+    "tag": null,
+    "description": "This playbook calculates migration data for each indicator type using information from global variables and legacy key stores.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [
+        "exclusion_details"
+    ],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/d4665980-9836-4181-9dc1-84dc61bfc696",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/eeea5155-181e-4bb4-ad07-2d5721b34173",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Compute Migration IOC List",
+            "description": null,
+            "arguments": {
+                "consolidatedIOCList": "{% set isGlobalEmpty = vars.globalVariableIOCList | length == 1 and vars.globalVariableIOCList[0] | length == 0 %}{% set isOldKeyStoreEmpty = vars.oldKeyStoreIOCList | length == 1 and vars.oldKeyStoreIOCList[0] | length == 0 %}{% if isGlobalEmpty and isOldKeyStoreEmpty %}{{ vars.exclusionDetails.excludedIOCs }}{% elif isOldKeyStoreEmpty %}{{ vars.exclusionDetails.excludedIOCs | union(vars.globalVariableIOCList) }}{% elif isGlobalEmpty %}{{ vars.exclusionDetails.excludedIOCs | union(vars.oldKeyStoreIOCList) }}{% else %}{{ vars.exclusionDetails.excludedIOCs | union(vars.globalVariableIOCList) | union(vars.oldKeyStoreIOCList) }}{% endif %}"
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "0f28a099-7c91-4850-8d39-ac0ef0649026"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "indicatorType": "{{vars.input.params['exclusion_details'].indicatorType}}",
+                "exclusionDetails": "{{vars.input.params['exclusion_details'].exclusionDetails}}",
+                "iocToKeystoreMapping": "{\n    \"IP Address\": \"sfsp-excludelist-ips\",\n    \"URL\": \"sfsp-excludelist-urls\",\n    \"Domain\": \"sfsp-excludelist-domains\",\n    \"Port\": \"sfsp-excludelist-ports\",\n    \"File\": \"sfsp-excludelist-files\",\n    \"CIDR Range\": \"sfsp-excludelist-cidr-ranges\"\n}"
+            },
+            "status": null,
+            "top": "165",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "90d580dd-657e-49dd-b6e6-e33bba53463b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Field Mapping from Global Variable",
+            "description": null,
+            "arguments": {
+                "gblVarFieldMapping": "{{vars.steps.Get_Global_Variable_IOC_List.data['hydra:member'][0].value}}"
+            },
+            "status": null,
+            "top": "570",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "acdfe04e-8b63-4d74-b8ea-250634606868"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Global Variable IOC List",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/dynamic-variable\/?name={{vars.exclusionDetails.globalVariable}}",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.4.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "globalVariableIOCList": "{% if vars.steps.Get_Global_Variable_IOC_List.data['hydra:member'] %}{{vars.steps.Get_Global_Variable_IOC_List.data['hydra:member'][0].value.split(',')}}{% else %}[]{% endif %}"
+                }
+            },
+            "status": null,
+            "top": "300",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "17bee73f-28d9-45ad-8d63-1b55917c26b0"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Old Keystore IOC List",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "key",
+                            "value": "{{vars.iocToKeystoreMapping[vars.indicatorType]}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "jSONValue"
+                    ]
+                },
+                "module": "keys?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "oldKeyStoreIOCList": "{% if vars.steps.Get_Old_Keystore_IOC_List %}{{vars.steps.Get_Old_Keystore_IOC_List[0].jSONValue}}{% else%}[]{% endif %}"
+                }
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "f0ff403f-25bc-43e5-b6c1-fa454c1ebd86"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Field Type Mapping",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/acdfe04e-8b63-4d74-b8ea-250634606868",
+                        "condition": "{{ vars.indicatorType == 'Indicator Type Mapping' }}",
+                        "step_name": "Updated Field Mapping"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/f0ff403f-25bc-43e5-b6c1-fa454c1ebd86",
+                        "step_name": "Get Old Keystore IOC List"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "b9948f59-cbb3-4725-a421-acceaf66debc"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "__triggerLimit": true,
+                "step_variables": {
+                    "input": {
+                        "params": []
+                    }
+                },
+                "triggerOnSource": true,
+                "triggerOnReplicate": false
+            },
+            "status": null,
+            "top": "30",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+            "group": null,
+            "uuid": "eeea5155-181e-4bb4-ad07-2d5721b34173"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Updated Exclusion List",
+            "description": null,
+            "arguments": {
+                "indicatorType": "{{vars.indicatorType}}",
+                "exclusionDetails": "{{vars.exclusionDetails | combine({'excludedIOCs': vars.consolidatedIOCList, 'migratedFromGlobalVariable': true})}}"
+            },
+            "status": null,
+            "top": "840",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "ab51e2b1-81ef-4e26-99bf-bb3bd2963f74"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Updated Field Mapping",
+            "description": null,
+            "arguments": {
+                "indicatorType": "{{vars.indicatorType}}",
+                "exclusionDetails": "{{vars.exclusionDetails | combine({'fieldTypeMapping':vars.gblVarFieldMapping, 'migratedFromGlobalVariable': true}, recursive=True)}}"
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "91c0fba0-0f97-426b-a7d6-15b84b2828f5"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Compute Migration IOC List -> Updated Exclusion List",
+            "targetStep": "\/api\/3\/workflow_steps\/ab51e2b1-81ef-4e26-99bf-bb3bd2963f74",
+            "sourceStep": "\/api\/3\/workflow_steps\/0f28a099-7c91-4850-8d39-ac0ef0649026",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "8acc5b58-c8b1-4257-9b33-cba1e0475f06"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Get Global Variable Value",
+            "targetStep": "\/api\/3\/workflow_steps\/17bee73f-28d9-45ad-8d63-1b55917c26b0",
+            "sourceStep": "\/api\/3\/workflow_steps\/90d580dd-657e-49dd-b6e6-e33bba53463b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "c897425c-e24a-40d2-b258-6af743c46404"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Field Mapping from Global Variable -> Copy of Updated Field Mapping",
+            "targetStep": "\/api\/3\/workflow_steps\/91c0fba0-0f97-426b-a7d6-15b84b2828f5",
+            "sourceStep": "\/api\/3\/workflow_steps\/acdfe04e-8b63-4d74-b8ea-250634606868",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "6ac8ae80-d472-4e28-a546-7cbb7c901ead"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Global Variable Value -> Is Field Type Mapping",
+            "targetStep": "\/api\/3\/workflow_steps\/b9948f59-cbb3-4725-a421-acceaf66debc",
+            "sourceStep": "\/api\/3\/workflow_steps\/17bee73f-28d9-45ad-8d63-1b55917c26b0",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "89b6d076-f85a-4c09-b309-dee59ee5ae23"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Old Keystore IOC List -> Compute Migration IOC List",
+            "targetStep": "\/api\/3\/workflow_steps\/0f28a099-7c91-4850-8d39-ac0ef0649026",
+            "sourceStep": "\/api\/3\/workflow_steps\/f0ff403f-25bc-43e5-b6c1-fa454c1ebd86",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "c58b79f2-0bfd-40be-8599-d8cf83e46833"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Field Type Mapping -> Copy of Updated Exclusion List",
+            "targetStep": "\/api\/3\/workflow_steps\/acdfe04e-8b63-4d74-b8ea-250634606868",
+            "sourceStep": "\/api\/3\/workflow_steps\/b9948f59-cbb3-4725-a421-acceaf66debc",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ade502a7-1a47-4157-b2b8-4fc9913d7456"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Field Type Mapping -> Get Old Keystore Value",
+            "targetStep": "\/api\/3\/workflow_steps\/f0ff403f-25bc-43e5-b6c1-fa454c1ebd86",
+            "sourceStep": "\/api\/3\/workflow_steps\/b9948f59-cbb3-4725-a421-acceaf66debc",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "7b1b8a69-76eb-4fc1-8e88-e7cf1b9d4180"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/90d580dd-657e-49dd-b6e6-e33bba53463b",
+            "sourceStep": "\/api\/3\/workflow_steps\/eeea5155-181e-4bb4-ad07-2d5721b34173",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "efc43e6e-c140-4724-82ae-9c2b71440737"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "uuid": "289228de-4857-43bb-a34d-94f26bf56725",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "Subroutine"
+    ]
+}

--- a/postInstall/workflow/Excluded Indicators Migration.json
+++ b/postInstall/workflow/Excluded Indicators Migration.json
@@ -1,0 +1,214 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Excluded Indicators Migration",
+    "aliasName": null,
+    "tag": null,
+    "description": "This playbook triggers after SOAR Framework deployment to migrate excluded indicators from global variables and legacy key store records to the new key store.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/d4665980-9836-4181-9dc1-84dc61bfc696",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/9e687367-0a0e-4116-9f19-129e888863cc",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Compute Migration Values",
+            "description": null,
+            "arguments": {
+                "updatedMigrationIOCList": "{{ vars.steps.Get_Migration_Values |  items2dict(key_name='indicatorType', value_name='exclusionDetails') }}"
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "1338d048-5eef-4662-a83c-081eeaf28c09"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": [],
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "df5abbe7-b1fc-485b-9a23-c451f7625471"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Exclusion Configuration",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "key",
+                            "value": "sfsp-indicator-extraction-configuration",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "jSONValue"
+                    ]
+                },
+                "module": "keys?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "exclusionConfiguration": "{{vars.steps.Get_Exclusion_Configuration[0].jSONValue}}"
+                }
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "1e204671-5137-4fb3-8985-98070c2ce0b2"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Migration Values",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Get_Exclusion_Configuration[0].jSONValue |  dict2items(key_name='indicatorType', value_name='exclusionDetails') }}",
+                    "parallel": false,
+                    "condition": "{{not vars.item.exclusionDetails.migratedFromGlobalVariable}}"
+                },
+                "arguments": {
+                    "exclusion_details": "{{vars.item}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "updatedMigrationIOCList": "{{vars.steps.Get_Migration_Values}}"
+                },
+                "pass_parent_env": false,
+                "pass_input_record": true,
+                "workflowReference": "\/api\/3\/workflows\/289228de-4857-43bb-a34d-94f26bf56725"
+            },
+            "status": null,
+            "top": "435",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "8c832d71-7a88-44d1-84b5-2042489f4a37"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "__triggerLimit": true,
+                "step_variables": {
+                    "input": {
+                        "params": []
+                    }
+                },
+                "triggerOnSource": true,
+                "triggerOnReplicate": false
+            },
+            "status": null,
+            "top": "30",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+            "group": null,
+            "uuid": "9e687367-0a0e-4116-9f19-129e888863cc"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Migrated Values",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "jSONValue": "{{vars.exclusionConfiguration | combine(vars.updatedMigrationIOCList)}}"
+                },
+                "operation": "Append",
+                "collection": "{{vars.steps.Get_Exclusion_Configuration[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/keys",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "d9585d8b-1018-45e8-8df6-4705d1857805"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Compute Migration Values -> Update Migrated Values",
+            "targetStep": "\/api\/3\/workflow_steps\/d9585d8b-1018-45e8-8df6-4705d1857805",
+            "sourceStep": "\/api\/3\/workflow_steps\/1338d048-5eef-4662-a83c-081eeaf28c09",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "311f85b5-63c3-4434-b31b-4658caf67109"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Get Exclusion Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/1e204671-5137-4fb3-8985-98070c2ce0b2",
+            "sourceStep": "\/api\/3\/workflow_steps\/df5abbe7-b1fc-485b-9a23-c451f7625471",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "4ab5929c-0e0a-4e44-8be2-a9be17fac3f6"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Exclusion Configuration -> Get Migration Values",
+            "targetStep": "\/api\/3\/workflow_steps\/8c832d71-7a88-44d1-84b5-2042489f4a37",
+            "sourceStep": "\/api\/3\/workflow_steps\/1e204671-5137-4fb3-8985-98070c2ce0b2",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ef8de1d9-4fdd-4ce9-85fd-d9f325c21d08"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Migration Values -> test",
+            "targetStep": "\/api\/3\/workflow_steps\/1338d048-5eef-4662-a83c-081eeaf28c09",
+            "sourceStep": "\/api\/3\/workflow_steps\/8c832d71-7a88-44d1-84b5-2042489f4a37",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "a3c7c2c9-cfd3-4a81-b299-ccb14b33b395"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/df5abbe7-b1fc-485b-9a23-c451f7625471",
+            "sourceStep": "\/api\/3\/workflow_steps\/9e687367-0a0e-4116-9f19-129e888863cc",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "f061924c-535e-45c0-a296-89bdf36fd987"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "uuid": "936f4403-593d-4d5a-a5ad-b8d04b4cbd3c",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "Referenced"
+    ]
+}

--- a/postInstall/workflow/collection.metadata.json
+++ b/postInstall/workflow/collection.metadata.json
@@ -1,0 +1,11 @@
+{
+    "@context": "\/api\/3\/contexts\/WorkflowCollection",
+    "@type": "WorkflowCollection",
+    "name": "Post-Install",
+    "description": null,
+    "visible": true,
+    "image": null,
+    "uuid": "d4665980-9836-4181-9dc1-84dc61bfc696",
+    "deletedAt": null,
+    "recordTags": []
+}

--- a/records/keys/keys0001.json
+++ b/records/keys/keys0001.json
@@ -1,136 +1,260 @@
 [
     {
         "@type": "Key",
-        "key": "sfsp-excludelist-cidr-ranges",
+        "key": "sfsp-indicator-extraction-configuration",
+        "value": "",
+        "jSONValue": {
+            "URL": {
+                "system": true,
+                "pattern": [
+                    "(?:https?|s?ftp):\\\/\\\/[^<>\\s\/$.?#].[^<>\\s,\\\"\\']*"
+                ],
+                "excludedIOCs": [
+                    "https:\/\/www.google.com",
+                    "https:\/\/mail.yahoo.com\/login.html",
+                    "https:\/\/www.office.com\/"
+                ],
+                "globalVariable": "Excludelist_URLs",
+                "applyIOCExtractionFilter": true,
+                "migratedFromGlobalVariable": true
+            },
+            "File": {
+                "system": true,
+                "pattern": [],
+                "excludedIOCs": [],
+                "globalVariable": "Excludelist_Files",
+                "applyIOCExtractionFilter": false,
+                "migratedFromGlobalVariable": true
+            },
+            "Port": {
+                "system": true,
+                "pattern": [
+                    "^(?:[1-9]\\d{0,3}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])$"
+                ],
+                "excludedIOCs": [],
+                "globalVariable": "Excludelist_Ports",
+                "applyIOCExtractionFilter": false,
+                "migratedFromGlobalVariable": true
+            },
+            "Domain": {
+                "system": true,
+                "pattern": [
+                    "\\b(([a-z0-9\\-]{2,}\\[?\\.\\]?)+(abogado|ac|academy|accountants|active|actor|ad|adult|ae|aero|af|ag|agency|ai|airforce|al|allfinanz|alsace|am|amsterdam|an|android|ao|aq|aquarelle|ar|archi|army|arpa|as|asia|associates|at|attorney|au|auction|audio|autos|aw|ax|axa|az|ba|band|bank|bar|barclaycard|barclays|bargains|bayern|bb|bd|be|beer|berlin|best|bf|bg|bh|bi|bid|bike|bingo|bio|biz|bj|black|blackfriday|bloomberg|blue|bm|bmw|bn|bnpparibas|bo|boo|boutique|br|brussels|bs|bt|budapest|build|builders|business|buzz|bv|bw|by|bz|bzh|ca|cal|camera|camp|cancerresearch|canon|capetown|capital|caravan|cards|care|career|careers|cartier|casa|cash|cat|catering|cc|cd|center|ceo|cern|cf|cg|ch|channel|chat|cheap|christmas|chrome|church|ci|citic|city|ck|cl|claims|cleaning|click|clinic|clothing|club|cm|cn|co|coach|codes|coffee|college|cologne|com|community|company|computer|condos|construction|consulting|contractors|cooking|cool|coop|country|cr|credit|creditcard|cricket|crs|cruises|cu|cuisinella|cv|cw|cx|cy|cymru|cz|dabur|dad|dance|dating|day|dclk|de|deals|degree|delivery|democrat|dental|dentist|desi|design|dev|diamonds|diet|digital|direct|directory|discount|dj|dk|dm|dnp|do|docs|domains|doosan|durban|dvag|dz|eat|ec|edu|education|ee|eg|email|emerck|energy|engineer|engineering|enterprises|equipment|er|es|esq|estate|et|eu|eurovision|eus|events|everbank|exchange|expert|exposed|fail|farm|fashion|feedback|fi|finance|financial|firmdale|fish|fishing|fit|fitness|fj|fk|flights|florist|flowers|flsmidth|fly|fm|fo|foo|forsale|foundation|fr|frl|frogans|fund|furniture|futbol|ga|gal|gallery|garden|gb|gbiz|gd|ge|gent|gf|gg|ggee|gh|gi|gift|gifts|gives|gl|glass|gle|global|globo|gm|gmail|gmo|gmx|gn|goog|google|gop|gov|gp|gq|gr|graphics|gratis|green|gripe|gs|gt|gu|guide|guitars|guru|gw|gy|hamburg|hangout|haus|healthcare|help|here|hermes|hiphop|hiv|hk|hm|hn|holdings|holiday|homes|horse|host|hosting|house|how|hr|ht|hu|ibm|id|ie|ifm|il|im|immo|immobilien|in|industries|info|ing|ink|institute|insure|int|international|investments|io|iq|ir|irish|is|it|iwc|jcb|je|jetzt|jm|jo|jobs|joburg|jp|juegos|kaufen|kddi|ke|kg|kh|ki|kim|kitchen|kiwi|km|kn|koeln|kp|kr|krd|kred|kw|ky|kyoto|kz|la|lacaixa|land|lat|latrobe|lawyer|lb|lc|lds|lease|legal|lgbt|li|lidl|life|lighting|limited|limo|link|lk|loans|local|london|lotte|lotto|lr|ls|lt|ltda|lu|luxe|luxury|lv|ly|ma|madrid|maison|management|mango|market|marketing|marriott|mc|md|me|media|meet|melbourne|meme|memorial|menu|mg|mh|miami|mil|mini|mk|ml|mm|mn|mo|mobi|moda|moe|monash|money|mormon|mortgage|moscow|motorcycles|mov|mp|mq|mr|ms|mt|mu|museum|mv|mw|mx|my|mz|na|nagoya|name|navy|nc|ne|net|network|neustar|new|nexus|nf|ng|ngo|nhk|ni|ninja|nl|no|np|nr|nra|nrw|ntt|nu|nyc|nz|okinawa|om|one|ong|onl|ooo|org|organic|osaka|otsuka|ovh|pa|paris|partners|parts|party|pe|pf|pg|ph|phd|pharmacy|photo|photography|photos|physio|pics|pictures|pink|pizza|pk|pl|place|plumbing|pm|pn|pohl|poker|porn|post|pr|praxi|press|pro|prod|productions|prof|properties|property|ps|pt|pub|pw|qa|qpon|quebec|re|realtor|recipes|red|rehab|reise|reisen|reit|ren|rentals|repair|report|republican|rest|restaurant|reviews|rich|rio|rip|ro|rocks|rodeo|rs|rsvp|ru|ruhr|rw|ryukyu|sa|saarland|sale|samsung|sarl|sb|sc|sca|scb|schmidt|schule|schwarz|science|scot|sd|se|services|sew|sexy|sg|sh|shiksha|shoes|shriram|si|singles|sj|sk|sky|sl|sm|sn|so|social|software|sohu|solar|solutions|soy|space|spiegel|sr|st|style|su|supplies|supply|support|surf|surgery|suzuki|sv|sx|sy|sydney|systems|sz|taipei|tatar|tattoo|tax|tc|td|technology|tel|temasek|tennis|tf|tg|th|tienda|tips|tires|tirol|tj|tk|tl|tm|tn|to|today|tokyo|tools|top|toshiba|town|toys|tp|tr|trade|training|travel|trust|tt|tui|tv|tw|tz|ua|ug|uk|university|uno|uol|us|uy|uz|va|vacations|vc|ve|vegas|ventures|versicherung|vet|vg|vi|viajes|video|villas|vision|vlaanderen|vn|vodka|vote|voting|voto|voyage|vu|wales|wang|watch|webcam|website|wed|wedding|wf|whoswho|wien|wiki|williamhill|wme|work|works|world|ws|wtc|wtf|xyz|yachts|yandex|ye|yoga|yokohama|youtube|yt|za|zm|zip|zone|zuerich|zw))\\b"
+                ],
+                "excludedIOCs": [
+                    "google.com",
+                    "yahoo.com",
+                    "fortinet.net",
+                    "gmail.com",
+                    "outlook.com",
+                    "microsoft.com",
+                    "fortinet.com",
+                    "twitter.com",
+                    "facebook.com",
+                    "linkedin.com",
+                    "instagram.com",
+                    "fortiguard.com",
+                    "forticloud.com",
+                    "w3.org"
+                ],
+                "globalVariable": "Excludelist_Domains",
+                "applyIOCExtractionFilter": true,
+                "migratedFromGlobalVariable": true
+            },
+            "File Hash": {
+                "system": true,
+                "pattern": [
+                    "\\b([a-f0-9]{32}|[A-F0-9]{32})\\b",
+                    "\\b([a-f0-9]{40}|[A-F0-9]{40})\\b",
+                    "\\b([a-f0-9]{64}|[A-F0-9]{64})\\b"
+                ],
+                "excludedIOCs": [],
+                "globalVariable": "NA",
+                "applyIOCExtractionFilter": true,
+                "migratedFromGlobalVariable": true
+            },
+            "CIDR Range": {
+                "system": true,
+                "pattern": [
+                    "^(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/(?:3[0-2]|[1-2]?[0-9])$"
+                ],
+                "excludedIOCs": [
+                    "10.0.0.0\/8",
+                    "172.16.0.0\/12",
+                    "192.168.0.0\/16"
+                ],
+                "globalVariable": "NA",
+                "applyIOCExtractionFilter": false,
+                "migratedFromGlobalVariable": true
+            },
+            "IP Address": {
+                "system": true,
+                "pattern": [
+                    "\\b(?:[2][5][0-5]\\.|[2][0-4][0-9]\\.|[1][0-9]{2}\\.|[1-9][0-9]\\.|[0-9]\\.){3}(?:[2][5][0-5]|[2][0-4][0-9]|[1][0-9]{2}|[1-9][0-9]|[0-9])\\b",
+                    "(?:(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){6})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:::(?:(?:(?:[0-9a-fA-F]{1,4})):){5})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:(?:[0-9a-fA-F]{1,4})):){4})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,1}(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:(?:[0-9a-fA-F]{1,4})):){3})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,2}(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:(?:[0-9a-fA-F]{1,4})):){2})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,3}(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:[0-9a-fA-F]{1,4})):)(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,4}(?:(?:[0-9a-fA-F]{1,4})))?::)(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,5}(?:(?:[0-9a-fA-F]{1,4})))?::)(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,6}(?:(?:[0-9a-fA-F]{1,4})))?::))))"
+                ],
+                "excludedIOCs": [
+                    "8.8.8.8",
+                    "10.1.1.2"
+                ],
+                "globalVariable": "Excludelist_IPs",
+                "applyIOCExtractionFilter": true,
+                "migratedFromGlobalVariable": true
+            },
+            "Indicator Type Mapping": {
+                "system": true,
+                "createFileIOCs": true,
+                "globalVariable": "Indicator_Type_Map",
+                "fieldTypeMapping": {
+                    "url": "URL",
+                    "domain": "Domain",
+                    "dLLName": "Process",
+                    "emailCc": "Email Address",
+                    "emailTo": "Email Address",
+                    "urlFull": "URL",
+                    "fileHash": "FileHash-MD5",
+                    "filehash": "FileHash-MD5",
+                    "reporter": "Email Address",
+                    "services": "Process",
+                    "sourceIP": "IP Address",
+                    "sourceIp": "IP Address",
+                    "userName": "User",
+                    "dllLoaded": "Process",
+                    "emailFrom": "Email Address",
+                    "fileHashes": "FileHash-MD5",
+                    "returnPath": "Email Address",
+                    "sourcePort": "Port",
+                    "commandLine": "Process",
+                    "iPAddresses": "IP Address",
+                    "processName": "Process",
+                    "registryKey": "Registry",
+                    "targetAsset": "Host",
+                    "userDetails": "User",
+                    "computerName": "Host",
+                    "senderDomain": "Domain",
+                    "destinationIP": "IP Address",
+                    "destinationIp": "IP Address",
+                    "sourceProcess": "Process",
+                    "targetProcess": "Process",
+                    "attachmentNames": "File",
+                    "destinationPort": "Port",
+                    "otherRecipients": "Email Address",
+                    "registryKeyValue": "Registry",
+                    "parentProcessName": "Process",
+                    "decodedCommandLine": "Process",
+                    "senderEmailAddress": "Email Address",
+                    "parentProcessCmdLine": "Process",
+                    "recipientEmailAddress": "Email Address",
+                    "receipientEmailAddress": "Email Address"
+                },
+                "addExcludedFileComment": false,
+                "applyIOCExtractionFilter": false,
+                "migratedFromGlobalVariable": true
+            }
+        },
+        "notes": "Contains excluded indicator list and indicator type mapping information",
+        "uuid": "955af050-a1e7-4b79-bda9-56c1ea8f79f3",
+        "createUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
+        "createDate": 1727280231.142605,
+        "modifyUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
+        "modifyDate": 1728907298.96862,
+        "tenant": "\/api\/3\/tenants\/b3a700f7-00be-4ef9-90c6-3c8fe6e1be63",
+        "conflict": false,
+        "tenantRecordId": 133,
+        "recordTags": [
+            "ExcludeListIOCs"
+        ]
+    },
+    {
+        "@type": "Key",
+        "key": "sfsp-indicator-regex-mapping",
         "value": null,
         "jSONValue": [
-            "10.0.0.0\/8",
-            "172.16.0.0\/12",
-            "192.168.0.0\/16"
+            {
+                "defang_regx": "(?:https?|hxxps?|hXXps?|s?ftp|fxp|fXp)(?::\\\/\\\/)[^<>\\s\/$.?#]+(?:\\[\\.\\]|\\.)[^<>\\s,\\\"\\']*",
+                "pattern_regx": "(?:https?|s?ftp):\\\/\\\/[^<>\\s\/$.?#].[^<>\\s,\\\"\\']*",
+                "indicator_type": "URL"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "\\b([a-f0-9]{32}|[A-F0-9]{32})\\b",
+                "indicator_type": "MD5"
+            },
+            {
+                "defang_regx": "\\b(([a-z0-9\\-]{2,}\\[?\\.\\]?)+(abogado|ac|academy|accountants|active|actor|ad|adult|ae|aero|af|ag|agency|ai|airforce|al|allfinanz|alsace|am|amsterdam|an|android|ao|aq|aquarelle|ar|archi|army|arpa|as|asia|associates|at|attorney|au|auction|audio|autos|aw|ax|axa|az|ba|band|bank|bar|barclaycard|barclays|bargains|bayern|bb|bd|be|beer|berlin|best|bf|bg|bh|bi|bid|bike|bingo|bio|biz|bj|black|blackfriday|bloomberg|blue|bm|bmw|bn|bnpparibas|bo|boo|boutique|br|brussels|bs|bt|budapest|build|builders|business|buzz|bv|bw|by|bz|bzh|ca|cal|camera|camp|cancerresearch|canon|capetown|capital|caravan|cards|care|career|careers|cartier|casa|cash|cat|catering|cc|cd|center|ceo|cern|cf|cg|ch|channel|chat|cheap|christmas|chrome|church|ci|citic|city|ck|cl|claims|cleaning|click|clinic|clothing|club|cm|cn|co|coach|codes|coffee|college|cologne|com|community|company|computer|condos|construction|consulting|contractors|cooking|cool|coop|country|cr|credit|creditcard|cricket|crs|cruises|cu|cuisinella|cv|cw|cx|cy|cymru|cz|dabur|dad|dance|dating|day|dclk|de|deals|degree|delivery|democrat|dental|dentist|desi|design|dev|diamonds|diet|digital|direct|directory|discount|dj|dk|dm|dnp|do|docs|domains|doosan|durban|dvag|dz|eat|ec|edu|education|ee|eg|email|emerck|energy|engineer|engineering|enterprises|equipment|er|es|esq|estate|et|eu|eurovision|eus|events|everbank|exchange|expert|exposed|fail|farm|fashion|feedback|fi|finance|financial|firmdale|fish|fishing|fit|fitness|fj|fk|flights|florist|flowers|flsmidth|fly|fm|fo|foo|forsale|foundation|fr|frl|frogans|fund|furniture|futbol|ga|gal|gallery|garden|gb|gbiz|gd|ge|gent|gf|gg|ggee|gh|gi|gift|gifts|gives|gl|glass|gle|global|globo|gm|gmail|gmo|gmx|gn|goog|google|gop|gov|gp|gq|gr|graphics|gratis|green|gripe|gs|gt|gu|guide|guitars|guru|gw|gy|hamburg|hangout|haus|healthcare|help|here|hermes|hiphop|hiv|hk|hm|hn|holdings|holiday|homes|horse|host|hosting|house|how|hr|ht|hu|ibm|id|ie|ifm|il|im|immo|immobilien|in|industries|info|ing|ink|institute|insure|int|international|investments|io|iq|ir|irish|is|it|iwc|jcb|je|jetzt|jm|jo|jobs|joburg|jp|juegos|kaufen|kddi|ke|kg|kh|ki|kim|kitchen|kiwi|km|kn|koeln|kp|kr|krd|kred|kw|ky|kyoto|kz|la|lacaixa|land|lat|latrobe|lawyer|lb|lc|lds|lease|legal|lgbt|li|lidl|life|lighting|limited|limo|link|lk|loans|local|london|lotte|lotto|lr|ls|lt|ltda|lu|luxe|luxury|lv|ly|ma|madrid|maison|management|mango|market|marketing|marriott|mc|md|me|media|meet|melbourne|meme|memorial|menu|mg|mh|miami|mil|mini|mk|ml|mm|mn|mo|mobi|moda|moe|monash|money|mormon|mortgage|moscow|motorcycles|mov|mp|mq|mr|ms|mt|mu|museum|mv|mw|mx|my|mz|na|nagoya|name|navy|nc|ne|net|network|neustar|new|nexus|nf|ng|ngo|nhk|ni|ninja|nl|no|np|nr|nra|nrw|ntt|nu|nyc|nz|okinawa|om|one|ong|onl|ooo|org|organic|osaka|otsuka|ovh|pa|paris|partners|parts|party|pe|pf|pg|ph|phd|pharmacy|photo|photography|photos|physio|pics|pictures|pink|pizza|pk|pl|place|plumbing|pm|pn|pohl|poker|porn|post|pr|praxi|press|pro|prod|productions|prof|properties|property|ps|pt|pub|pw|qa|qpon|quebec|re|realtor|recipes|red|rehab|reise|reisen|reit|ren|rentals|repair|report|republican|rest|restaurant|reviews|rich|rio|rip|ro|rocks|rodeo|rs|rsvp|ru|ruhr|rw|ryukyu|sa|saarland|sale|samsung|sarl|sb|sc|sca|scb|schmidt|schule|schwarz|science|scot|sd|se|services|sew|sexy|sg|sh|shiksha|shoes|shriram|si|singles|sj|sk|sky|sl|sm|sn|so|social|software|sohu|solar|solutions|soy|space|spiegel|sr|st|style|su|supplies|supply|support|surf|surgery|suzuki|sv|sx|sy|sydney|systems|sz|taipei|tatar|tattoo|tax|tc|td|technology|tel|temasek|tennis|tf|tg|th|tienda|tips|tires|tirol|tj|tk|tl|tm|tn|to|today|tokyo|tools|top|toshiba|town|toys|tp|tr|trade|training|travel|trust|tt|tui|tv|tw|tz|ua|ug|uk|university|uno|uol|us|uy|uz|va|vacations|vc|ve|vegas|ventures|versicherung|vet|vg|vi|viajes|video|villas|vision|vlaanderen|vn|vodka|vote|voting|voto|voyage|vu|wales|wang|watch|webcam|website|wed|wedding|wf|whoswho|wien|wiki|williamhill|wme|work|works|world|ws|wtc|wtf|xyz|yachts|yandex|ye|yoga|yokohama|youtube|yt|za|zm|zip|zone|zuerich|zw))\\b",
+                "pattern_regx": "\\b(([a-z0-9\\-]{2,}\\.)+(abogado|ac|academy|accountants|active|actor|ad|adult|ae|aero|af|ag|agency|ai|airforce|al|allfinanz|alsace|am|amsterdam|an|android|ao|aq|aquarelle|ar|archi|army|arpa|as|asia|associates|at|attorney|au|auction|audio|autos|aw|ax|axa|az|ba|band|bank|bar|barclaycard|barclays|bargains|bayern|bb|bd|be|beer|berlin|best|bf|bg|bh|bi|bid|bike|bingo|bio|biz|bj|black|blackfriday|bloomberg|blue|bm|bmw|bn|bnpparibas|bo|boo|boutique|br|brussels|bs|bt|budapest|build|builders|business|buzz|bv|bw|by|bz|bzh|ca|cal|camera|camp|cancerresearch|canon|capetown|capital|caravan|cards|care|career|careers|cartier|casa|cash|cat|catering|cc|cd|center|ceo|cern|cf|cg|ch|channel|chat|cheap|christmas|chrome|church|ci|citic|city|ck|cl|claims|cleaning|click|clinic|clothing|club|cm|cn|co|coach|codes|coffee|college|cologne|com|community|company|computer|condos|construction|consulting|contractors|cooking|cool|coop|country|cr|credit|creditcard|cricket|crs|cruises|cu|cuisinella|cv|cw|cx|cy|cymru|cz|dabur|dad|dance|dating|day|dclk|de|deals|degree|delivery|democrat|dental|dentist|desi|design|dev|diamonds|diet|digital|direct|directory|discount|dj|dk|dm|dnp|do|docs|domains|doosan|durban|dvag|dz|eat|ec|edu|education|ee|eg|email|emerck|energy|engineer|engineering|enterprises|equipment|er|es|esq|estate|et|eu|eurovision|eus|events|everbank|exchange|expert|exposed|fail|farm|fashion|feedback|fi|finance|financial|firmdale|fish|fishing|fit|fitness|fj|fk|flights|florist|flowers|flsmidth|fly|fm|fo|foo|forsale|foundation|fr|frl|frogans|fund|furniture|futbol|ga|gal|gallery|garden|gb|gbiz|gd|ge|gent|gf|gg|ggee|gh|gi|gift|gifts|gives|gl|glass|gle|global|globo|gm|gmail|gmo|gmx|gn|goog|google|gop|gov|gp|gq|gr|graphics|gratis|green|gripe|gs|gt|gu|guide|guitars|guru|gw|gy|hamburg|hangout|haus|healthcare|help|here|hermes|hiphop|hiv|hk|hm|hn|holdings|holiday|homes|horse|host|hosting|house|how|hr|ht|hu|ibm|id|ie|ifm|il|im|immo|immobilien|in|industries|info|ing|ink|institute|insure|int|international|investments|io|iq|ir|irish|is|it|iwc|jcb|je|jetzt|jm|jo|jobs|joburg|jp|juegos|kaufen|kddi|ke|kg|kh|ki|kim|kitchen|kiwi|km|kn|koeln|kp|kr|krd|kred|kw|ky|kyoto|kz|la|lacaixa|land|lat|latrobe|lawyer|lb|lc|lds|lease|legal|lgbt|li|lidl|life|lighting|limited|limo|link|lk|loans|local|london|lotte|lotto|lr|ls|lt|ltda|lu|luxe|luxury|lv|ly|ma|madrid|maison|management|mango|market|marketing|marriott|mc|md|me|media|meet|melbourne|meme|memorial|menu|mg|mh|miami|mil|mini|mk|ml|mm|mn|mo|mobi|moda|moe|monash|money|mormon|mortgage|moscow|motorcycles|mov|mp|mq|mr|ms|mt|mu|museum|mv|mw|mx|my|mz|na|nagoya|name|navy|nc|ne|net|network|neustar|new|nexus|nf|ng|ngo|nhk|ni|ninja|nl|no|np|nr|nra|nrw|ntt|nu|nyc|nz|okinawa|om|one|ong|onl|ooo|org|organic|osaka|otsuka|ovh|pa|paris|partners|parts|party|pe|pf|pg|ph|phd|pharmacy|photo|photography|photos|physio|pics|pictures|pink|pizza|pk|pl|place|plumbing|pm|pn|pohl|poker|porn|post|pr|praxi|press|pro|prod|productions|prof|properties|property|ps|pt|pub|pw|qa|qpon|quebec|re|realtor|recipes|red|rehab|reise|reisen|reit|ren|rentals|repair|report|republican|rest|restaurant|reviews|rich|rio|rip|ro|rocks|rodeo|rs|rsvp|ru|ruhr|rw|ryukyu|sa|saarland|sale|samsung|sarl|sb|sc|sca|scb|schmidt|schule|schwarz|science|scot|sd|se|services|sew|sexy|sg|sh|shiksha|shoes|shriram|si|singles|sj|sk|sky|sl|sm|sn|so|social|software|sohu|solar|solutions|soy|space|spiegel|sr|st|style|su|supplies|supply|support|surf|surgery|suzuki|sv|sx|sy|sydney|systems|sz|taipei|tatar|tattoo|tax|tc|td|technology|tel|temasek|tennis|tf|tg|th|tienda|tips|tires|tirol|tj|tk|tl|tm|tn|to|today|tokyo|tools|top|toshiba|town|toys|tp|tr|trade|training|travel|trust|tt|tui|tv|tw|tz|ua|ug|uk|university|uno|uol|us|uy|uz|va|vacations|vc|ve|vegas|ventures|versicherung|vet|vg|vi|viajes|video|villas|vision|vlaanderen|vn|vodka|vote|voting|voto|voyage|vu|wales|wang|watch|webcam|website|wed|wedding|wf|whoswho|wien|wiki|williamhill|wme|work|works|world|ws|wtc|wtf|xyz|yachts|yandex|ye|yoga|yokohama|youtube|yt|za|zm|zip|zone|zuerich|zw))\\b",
+                "indicator_type": "Host"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "",
+                "indicator_type": "Domain"
+            },
+            {
+                "defang_regx": "\\b(?:[2][5][0-5](?:\\[\\.\\]|\\.)|[2][0-4][0-9](?:\\[\\.\\]|\\.)|[1][0-9]{2}(?:\\[\\.\\]|\\.)|[1-9][0-9](?:\\[\\.\\]|\\.)|[0-9](?:\\[\\.\\]|\\.)){3}(?:[2][5][0-5]|[2][0-4][0-9]|[1][0-9]{2}|[1-9][0-9]|[0-9])\\b",
+                "pattern_regx": "\\b(?:[2][5][0-5]\\.|[2][0-4][0-9]\\.|[1][0-9]{2}\\.|[1-9][0-9]\\.|[0-9]\\.){3}(?:[2][5][0-5]|[2][0-4][0-9]|[1][0-9]{2}|[1-9][0-9]|[0-9])\\b",
+                "indicator_type": "IPv4"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "(?:(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){6})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:::(?:(?:(?:[0-9a-fA-F]{1,4})):){5})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:(?:[0-9a-fA-F]{1,4})):){4})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,1}(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:(?:[0-9a-fA-F]{1,4})):){3})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,2}(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:(?:[0-9a-fA-F]{1,4})):){2})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,3}(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:[0-9a-fA-F]{1,4})):)(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,4}(?:(?:[0-9a-fA-F]{1,4})))?::)(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,5}(?:(?:[0-9a-fA-F]{1,4})))?::)(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,6}(?:(?:[0-9a-fA-F]{1,4})))?::))))",
+                "indicator_type": "IPv6"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "[a-zA-Z0-9\\.\\-+_]+@[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-+_]*\\.[a-zA-Z0-9]{1,4}",
+                "indicator_type": "Email"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "\\b([a-f0-9]{40}|[A-F0-9]{40})\\b",
+                "indicator_type": "SHA1"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "\\b([a-f0-9]{64}|[A-F0-9]{64})\\b",
+                "indicator_type": "SHA256"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "\\b(CVE\\-[0-9]{4}\\-[0-9]{4,6})\\b",
+                "indicator_type": "CVE"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "\\b((HKLM|HKCU)\\\\[\\\\A-Za-z0-9-_]+)\\b",
+                "indicator_type": "Registry"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "\\b([A-Za-z0-9-_\\.]+\\.(exe|dll|bat|sys|htm|html|js|jar|jpg|png|vb|scr|pif|chm|zip|rar|cab|pdf|doc|docx|ppt|pptx|xls|xlsx|swf|gif|tgz|json))\\b",
+                "indicator_type": "Filename"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "(?:<[^>]+>)|(?:\\b[A-Z]:\\\\[A-Za-z0-9-_\\.\\\\']+\\b|\\\/[A-Za-z0-9-_\\.\\\/\\\\]*)",
+                "indicator_type": "Filepath"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "^(?:[1-9]\\d{0,3}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])$",
+                "indicator_type": "Port"
+            },
+            {
+                "defang_regx": "",
+                "pattern_regx": "^(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/(?:3[0-2]|[1-2]?[0-9])$",
+                "indicator_type": "CIDR Range"
+            }
         ],
-        "notes": "Enter the CIDR ranges that you want to exclude from enrichment.",
-        "uuid": "ed651d15-282c-4a3c-9776-4ddafcf9d4f0",
+        "notes": "Contains validation regex and defang regex for indicator types",
+        "uuid": "f8724f45-4873-48c5-b922-d91bb723d29b",
         "createUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "createDate": 1719573524.72596,
+        "createDate": 1726817135.237371,
         "modifyUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "modifyDate": 1719573528.571059,
+        "modifyDate": 1728907337.420278,
         "tenant": "\/api\/3\/tenants\/b3a700f7-00be-4ef9-90c6-3c8fe6e1be63",
         "conflict": false,
-        "tenantRecordId": 74,
-        "recordTags": [
-            "ExcludeListIOCs"
-        ]
-    },
-    {
-        "@type": "Key",
-        "key": "sfsp-excludelist-ips",
-        "value": null,
-        "jSONValue": [
-            "8.8.8.8",
-            "10.1.1.2"
-        ],
-        "notes": "Enter the ips that you want to exclude from enrichment.",
-        "uuid": "ef7e25e3-5058-486b-80c1-9bf9226f367b",
-        "createUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "createDate": 1719573524.840729,
-        "modifyUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "modifyDate": 1719573528.570289,
-        "tenant": "\/api\/3\/tenants\/b3a700f7-00be-4ef9-90c6-3c8fe6e1be63",
-        "conflict": false,
-        "tenantRecordId": 78,
-        "recordTags": [
-            "ExcludeListIOCs"
-        ]
-    },
-    {
-        "@type": "Key",
-        "key": "sfsp-excludelist-files",
-        "value": null,
-        "jSONValue": "",
-        "notes": "Enter the files that you want to exclude from enrichment.",
-        "uuid": "8c34dcc2-b5ce-460e-8372-b1b6709460e4",
-        "createUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "createDate": 1719573524.835305,
-        "modifyUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "modifyDate": 1719573528.572637,
-        "tenant": "\/api\/3\/tenants\/b3a700f7-00be-4ef9-90c6-3c8fe6e1be63",
-        "conflict": false,
-        "tenantRecordId": 77,
-        "recordTags": [
-            "ExcludeListIOCs"
-        ]
-    },
-    {
-        "@type": "Key",
-        "key": "sfsp-excludelist-urls",
-        "value": null,
-        "jSONValue": [
-            "https:\/\/www.google.com",
-            "https:\/\/mail.yahoo.com\/login.html",
-            "https:\/\/www.office.com\/"
-        ],
-        "notes": "Enter the urls that you want to exclude from enrichment.",
-        "uuid": "438cdd54-1ed3-4935-bd12-bf5fe233a7d2",
-        "createUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "createDate": 1719573524.813545,
-        "modifyUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "modifyDate": 1719573528.577797,
-        "tenant": "\/api\/3\/tenants\/b3a700f7-00be-4ef9-90c6-3c8fe6e1be63",
-        "conflict": false,
-        "tenantRecordId": 75,
-        "recordTags": [
-            "ExcludeListIOCs"
-        ]
-    },
-    {
-        "@type": "Key",
-        "key": "sfsp-excludelist-domains",
-        "value": null,
-        "jSONValue": [
-            "google.com",
-            "yahoo.com",
-            "fortinet.net",
-            "gmail.com",
-            "outlook.com",
-            "microsoft.com",
-            "fortinet.com",
-            "twitter.com",
-            "facebook.com",
-            "linkedin.com",
-            "instagram.com",
-            "fortiguard.com",
-            "forticloud.com",
-            "w3.org"
-        ],
-        "notes": "Enter the domains that you want to exclude from enrichment.",
-        "uuid": "a7d9e8af-5912-4090-b9dd-ee686a0af6b4",
-        "createUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "createDate": 1719573524.815153,
-        "modifyUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "modifyDate": 1719573528.580807,
-        "tenant": "\/api\/3\/tenants\/b3a700f7-00be-4ef9-90c6-3c8fe6e1be63",
-        "conflict": false,
-        "tenantRecordId": 76,
-        "recordTags": [
-            "ExcludeListIOCs"
-        ]
-    },
-    {
-        "@type": "Key",
-        "key": "sfsp-excludelist-ports",
-        "value": null,
-        "jSONValue": "",
-        "notes": "Enter the ports that you want to exclude from enrichment.",
-        "uuid": "fccb9763-d682-4662-be84-c724ce355941",
-        "createUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "createDate": 1719573524.921418,
-        "modifyUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-        "modifyDate": 1719573528.695446,
-        "tenant": "\/api\/3\/tenants\/b3a700f7-00be-4ef9-90c6-3c8fe6e1be63",
-        "conflict": false,
-        "tenantRecordId": 79,
-        "recordTags": [
-            "ExcludeListIOCs"
-        ]
+        "tenantRecordId": 146,
+        "recordTags": []
     }
 ]


### PR DESCRIPTION
## UTCs

### Validate Key Store Records  

**Test Steps:**  
1. Open the key store page
2. Verify that the record "sfsp-indicator-extraction-configuration" is present.  
3. Verify that the record "sfsp-indicator-regex-pattern" is present.

**Expected Results:**  
- Both "sfsp-indicator-extraction-configuration" and "sfsp-indicator-regex-pattern" records should be added to the key store.

---

### Validate Post-SFSP Deployment Playbook Execution  

**Preconditions:**  
- FortiSOAR 7.6.1-306 and above

**Test Steps:**  
1. Check if the post-SFSP deployment playbooks are executed.  
2. Monitor the execution process.

**Expected Results:**  
- The post-SFSP deployment playbooks should execute successfully without errors.

---

### Validate Execution of Migration Playbook  

**Preconditions:**  
- FortiSOAR 7.6.1-306 and above
- Access to both legacy and new keystores is available.  

**Test Steps:**  
1. Execute the post-deployment migration playbooks.  
2. Verify the migration of legacy keystore records:  
   - Confirm that the following existing keystore values are migrated to the **sfsp-indicator-extraction-configuration** Keystore:  
     - **sfsp-excludelist-cidr-ranges**  
     - **sfsp-excludelist-ips**  
     - **sfsp-excludelist-files**  
     - **sfsp-excludelist-urls**  
     - **sfsp-excludelist-domains**  
     - **sfsp-excludelist-ports**  
3. Verify the migration of global variables:  
   - Confirm that values from the following existing global variables are migrated to the new key store:  
     - **Indicator_Type_Map**  
     - **Excludelist_Domains**  
     - **Excludelist_Files**  
     - **Excludelist_IPs**  
     - **Excludelist_Ports**  
     - **Excludelist_URLs**  

**Expected Results:**  
- All specified values from the global variable and legacy keystore records should be successfully migrated to the **sfsp-indicator-extraction-configuration**  keystore record.


