### PR TITLE
QABugFixes-2

### DIFF
--- a/playbooks/06 - IRP - Case Management/Alert - Close Corresponding SIEM Alert.json
+++ b/playbooks/06 - IRP - Case Management/Alert - Close Corresponding SIEM Alert.json
@@ -114,6 +114,8 @@
     "priority": null,
     "uuid": "11ca0960-376d-4406-90c0-877b92a2d7b0",
     "owners": [],
+    "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
+    "isEditable": true,
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [


### PR DESCRIPTION
- Marked `06 - IRP - Case Management > Alert - Close Corresponding SIEM Alert` playbook as **true**

### Reason to mark editable
- This playbook shows a pop-up when closing an alert, asking if the user wants to close the alert in SIEM as well. 
- Just like Action playbooks, it has manual input step, which can be replaced by a SIEM connector step.